### PR TITLE
fix: prevent first-boot flood when AUTO_TRIAGE_NEW_ISSUES=true

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -81,6 +81,10 @@ POLL_INTERVAL_MINUTES=2
 # Max concurrent agent-work sessions (implementation + rework combined).
 MAX_CONCURRENT_WORK=10
 
+# Max concurrent triage/review sessions (issue triage + PR review combined).
+# Falls back to MAX_CONCURRENT_WORK if not set.
+MAX_CONCURRENT_TRIAGE=10
+
 # Max trigger dispatches per poll cycle. Prevents a single cycle from
 # flooding the system (e.g., first boot with many existing issues).
 # Items beyond this limit are deferred to the next cycle.

--- a/triggers/on-new-issue.sh
+++ b/triggers/on-new-issue.sh
@@ -26,7 +26,16 @@ PROJECT_SLUG="${4:-${CURRENT_PROJECT:-default}}"
 set_project "$PROJECT_SLUG"
 
 ITEM_STATE_FILE=$(create_item_state "$REPO" "issue" "$ISSUE_NUMBER" "running" "$PROJECT_SLUG") || true
-trap 'cleanup_on_exit "" "$ITEM_STATE_FILE" $?' EXIT
+
+# --- Concurrency Slot ---
+SLOT_DIR="$SCRIPT_DIR/state/triage-slots"
+MAX_CONCURRENT=${MAX_CONCURRENT_TRIAGE:-${MAX_CONCURRENT_WORK:-10}}
+if ! acquire_slot "$SLOT_DIR" "$MAX_CONCURRENT"; then
+    log_warn "At capacity ($MAX_CONCURRENT concurrent triage sessions), deferring issue #${ISSUE_NUMBER} (will retry in ~5 min)"
+    [[ -n "$ITEM_STATE_FILE" && -f "$ITEM_STATE_FILE" ]] && update_item_state "$ITEM_STATE_FILE" "capacity_rejected"
+    exit 0
+fi
+trap 'cleanup_on_exit "$SLOT_FILE" "$ITEM_STATE_FILE" $?' EXIT
 
 log_info "Triaging issue #${ISSUE_NUMBER} in ${REPO} (project: $PROJECT_SLUG)"
 

--- a/triggers/on-new-pr.sh
+++ b/triggers/on-new-pr.sh
@@ -26,7 +26,16 @@ PROJECT_SLUG="${4:-${CURRENT_PROJECT:-default}}"
 set_project "$PROJECT_SLUG"
 
 ITEM_STATE_FILE=$(create_item_state "$REPO" "pr" "$PR_NUMBER" "running" "$PROJECT_SLUG") || true
-trap 'cleanup_on_exit "" "$ITEM_STATE_FILE" $?' EXIT
+
+# --- Concurrency Slot ---
+SLOT_DIR="$SCRIPT_DIR/state/triage-slots"
+MAX_CONCURRENT=${MAX_CONCURRENT_TRIAGE:-${MAX_CONCURRENT_WORK:-10}}
+if ! acquire_slot "$SLOT_DIR" "$MAX_CONCURRENT"; then
+    log_warn "At capacity ($MAX_CONCURRENT concurrent triage sessions), deferring PR #${PR_NUMBER} (will retry in ~5 min)"
+    [[ -n "$ITEM_STATE_FILE" && -f "$ITEM_STATE_FILE" ]] && update_item_state "$ITEM_STATE_FILE" "capacity_rejected"
+    exit 0
+fi
+trap 'cleanup_on_exit "$SLOT_FILE" "$ITEM_STATE_FILE" $?' EXIT
 
 log_info "Reviewing PR #${PR_NUMBER} in ${REPO} (project: $PROJECT_SLUG)"
 


### PR DESCRIPTION
## Summary

Closes #4

When `processed-issues.txt` is empty (fresh install), the poller treats every open issue as newly created and spawns triage sessions for all of them, overwhelming the system.

This PR fixes the root cause and adds defense-in-depth:

- **Fix startup ordering race condition**: Move state file seeding _before_ cron installation in `bin/startup.sh` to prevent the first poll from firing before seeding completes
- **Add triage/review concurrency limits**: Apply slot-based concurrency (`MAX_CONCURRENT_TRIAGE`) to `on-new-issue.sh` and `on-new-pr.sh` — the only two triggers that lacked it
- **Seed `processed-rework.txt` on first boot**: Close a minor gap where rework PRs could be re-dispatched after a fresh install

## Changes

| File | Change |
|------|--------|
| `bin/startup.sh` | Move state seeding (step 6) before cron install (step 7); seed `processed-rework.txt` in PR loop |
| `triggers/on-new-issue.sh` | Add `triage-slots` concurrency with `MAX_CONCURRENT_TRIAGE` |
| `triggers/on-new-pr.sh` | Add `triage-slots` concurrency with `MAX_CONCURRENT_TRIAGE` |
| `.env.example` | Document `MAX_CONCURRENT_TRIAGE=10` |

## Test plan

- [ ] Run `bash -n` on all modified scripts (done — all pass)
- [ ] Fresh install: verify `processed-*.txt` files are seeded before cron starts
- [ ] Verify triage trigger respects `MAX_CONCURRENT_TRIAGE` slot limit
- [ ] Verify PR review trigger respects `MAX_CONCURRENT_TRIAGE` slot limit
- [ ] Verify capacity-rejected items auto-retry in ~5 min via `item-state.sh`
- [ ] Confirm existing concurrency in other triggers is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)