### PR TITLE
fix: bind dashboard to localhost and improve ProjectSelector accessibility

### DIFF
--- a/bin/startup.sh
+++ b/bin/startup.sh
@@ -304,7 +304,7 @@ fi
 # Start dashboard as a background process
 if [[ -d "$DASHBOARD_DIR/.next" ]]; then
     cd "$DASHBOARD_DIR"
-    AUTOMATION_DIR="$SCRIPT_DIR" nohup npx next start -H 0.0.0.0 -p "$DASHBOARD_PORT" \
+    AUTOMATION_DIR="$SCRIPT_DIR" nohup npx next start -H 127.0.0.1 -p "$DASHBOARD_PORT" \
         >> "$DASHBOARD_LOG" 2>&1 &
     echo $! > "$DASHBOARD_PID_FILE"
     cd "$SCRIPT_DIR"

--- a/dashboard/src/components/ProjectSelector.tsx
+++ b/dashboard/src/components/ProjectSelector.tsx
@@ -2,13 +2,22 @@
 
 import { useProject } from '@/hooks/useProject'
 import { cn } from '@/lib/utils'
-import { ChevronDown } from 'lucide-react'
-import { useEffect, useRef, useState } from 'react'
+import { Check, ChevronDown } from 'lucide-react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 export function ProjectSelector({ className }: { className?: string }) {
   const { project, projectName, projects, setProject } = useProject()
   const [open, setOpen] = useState(false)
+  const [focusIndex, setFocusIndex] = useState(-1)
   const ref = useRef<HTMLDivElement>(null)
+  const buttonRef = useRef<HTMLButtonElement>(null)
+  const listRef = useRef<HTMLDivElement>(null)
+
+  // "All Projects" + each project
+  const options = [
+    { slug: undefined as string | undefined, name: 'All Projects' },
+    ...projects.map((p) => ({ slug: p.slug as string | undefined, name: p.name })),
+  ]
 
   useEffect(() => {
     function handleClickOutside(e: MouseEvent) {
@@ -20,15 +29,87 @@ export function ProjectSelector({ className }: { className?: string }) {
     return () => document.removeEventListener('mousedown', handleClickOutside)
   }, [])
 
+  // Reset focus index when dropdown opens
+  useEffect(() => {
+    if (open) {
+      const currentIdx = project
+        ? options.findIndex((o) => o.slug === project)
+        : 0
+      setFocusIndex(currentIdx)
+    }
+  }, [open]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (!open) {
+        if (e.key === 'ArrowDown' || e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          setOpen(true)
+          return
+        }
+        return
+      }
+
+      switch (e.key) {
+        case 'ArrowDown':
+          e.preventDefault()
+          setFocusIndex((i) => Math.min(i + 1, options.length - 1))
+          break
+        case 'ArrowUp':
+          e.preventDefault()
+          setFocusIndex((i) => Math.max(i - 1, 0))
+          break
+        case 'Enter':
+        case ' ':
+          e.preventDefault()
+          if (focusIndex >= 0 && focusIndex < options.length) {
+            setProject(options[focusIndex].slug)
+            setOpen(false)
+            buttonRef.current?.focus()
+          }
+          break
+        case 'Escape':
+          e.preventDefault()
+          setOpen(false)
+          buttonRef.current?.focus()
+          break
+        case 'Home':
+          e.preventDefault()
+          setFocusIndex(0)
+          break
+        case 'End':
+          e.preventDefault()
+          setFocusIndex(options.length - 1)
+          break
+      }
+    },
+    [open, focusIndex, options, setProject],
+  )
+
+  // Scroll focused option into view
+  useEffect(() => {
+    if (open && listRef.current && focusIndex >= 0) {
+      const items = listRef.current.querySelectorAll('[role="option"]')
+      items[focusIndex]?.scrollIntoView({ block: 'nearest' })
+    }
+  }, [focusIndex, open])
+
   // Don't show selector if there's only one project (or none)
   if (projects.length <= 1) {
     return null
   }
 
+  const listboxId = 'project-selector-listbox'
+
   return (
-    <div ref={ref} className={cn('relative', className)}>
+    <div ref={ref} className={cn('relative', className)} onKeyDown={handleKeyDown}>
       <button
+        ref={buttonRef}
         onClick={() => setOpen(!open)}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-controls={open ? listboxId : undefined}
+        aria-label={`Project: ${projectName}`}
         className={cn(
           'flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-sm font-medium transition',
           'text-zinc-600 hover:text-zinc-900 hover:bg-zinc-100',
@@ -41,32 +122,41 @@ export function ProjectSelector({ className }: { className?: string }) {
       </button>
 
       {open && (
-        <div className="absolute left-0 top-full z-50 mt-1 min-w-[180px] rounded-lg border border-zinc-200 bg-white py-1 shadow-lg dark:border-zinc-700 dark:bg-zinc-800">
-          <button
-            onClick={() => { setProject(undefined); setOpen(false) }}
-            className={cn(
-              'flex w-full items-center px-3 py-2 text-left text-sm transition',
-              !project
-                ? 'bg-emerald-50 text-emerald-700 dark:bg-emerald-500/10 dark:text-emerald-400'
-                : 'text-zinc-600 hover:bg-zinc-50 dark:text-zinc-300 dark:hover:bg-zinc-700/50',
-            )}
-          >
-            All Projects
-          </button>
-          {projects.map((p) => (
-            <button
-              key={p.slug}
-              onClick={() => { setProject(p.slug); setOpen(false) }}
-              className={cn(
-                'flex w-full items-center px-3 py-2 text-left text-sm transition',
-                project === p.slug
-                  ? 'bg-emerald-50 text-emerald-700 dark:bg-emerald-500/10 dark:text-emerald-400'
-                  : 'text-zinc-600 hover:bg-zinc-50 dark:text-zinc-300 dark:hover:bg-zinc-700/50',
-              )}
-            >
-              {p.name}
-            </button>
-          ))}
+        <div
+          ref={listRef}
+          id={listboxId}
+          role="listbox"
+          aria-label="Select project"
+          aria-activedescendant={focusIndex >= 0 ? `project-option-${focusIndex}` : undefined}
+          className="absolute left-0 top-full z-50 mt-1 min-w-[180px] max-h-[280px] overflow-y-auto rounded-lg border border-zinc-200 bg-white py-1 shadow-lg dark:border-zinc-700 dark:bg-zinc-800"
+        >
+          {options.map((opt, idx) => {
+            const isSelected = opt.slug === project || (!opt.slug && !project)
+            return (
+              <button
+                key={opt.slug ?? '__all'}
+                id={`project-option-${idx}`}
+                role="option"
+                aria-selected={isSelected}
+                onClick={() => { setProject(opt.slug); setOpen(false); buttonRef.current?.focus() }}
+                className={cn(
+                  'flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition',
+                  isSelected
+                    ? 'bg-emerald-50 text-emerald-700 dark:bg-emerald-500/10 dark:text-emerald-400'
+                    : 'text-zinc-600 hover:bg-zinc-50 dark:text-zinc-300 dark:hover:bg-zinc-700/50',
+                  focusIndex === idx && 'ring-2 ring-inset ring-emerald-500',
+                )}
+              >
+                <Check
+                  className={cn(
+                    'h-3.5 w-3.5 shrink-0',
+                    isSelected ? 'opacity-100' : 'opacity-0',
+                  )}
+                />
+                {opt.name}
+              </button>
+            )
+          })}
         </div>
       )}
     </div>

--- a/src/commands/dashboard.mjs
+++ b/src/commands/dashboard.mjs
@@ -28,7 +28,7 @@ function runDashboard(opts) {
       return;
     }
     console.log(`Starting Next.js dev server on port ${devPort}...`);
-    execSync(`npm run dev -- -p ${devPort}`, { cwd: dashboardDir, stdio: 'inherit', env: automationEnv });
+    execSync(`npm run dev -- -H 127.0.0.1 -p ${devPort}`, { cwd: dashboardDir, stdio: 'inherit', env: automationEnv });
     return;
   }
 
@@ -40,7 +40,7 @@ function runDashboard(opts) {
       return;
     }
     console.log(`Starting Next.js production server on port ${port}...`);
-    execSync(`npm run start -- -p ${port}`, { cwd: dashboardDir, stdio: 'inherit', env: automationEnv });
+    execSync(`npm run start -- -H 127.0.0.1 -p ${port}`, { cwd: dashboardDir, stdio: 'inherit', env: automationEnv });
     return;
   }
 
@@ -72,8 +72,8 @@ function serveDashboard(port) {
     }
   });
 
-  server.listen(port, '0.0.0.0', () => {
-    console.log(`Dashboard server running at http://0.0.0.0:${port} (cache TTL: 5m)`);
+  server.listen(port, '127.0.0.1', () => {
+    console.log(`Dashboard server running at http://127.0.0.1:${port} (cache TTL: 5m)`);
   });
 }
 


### PR DESCRIPTION
## Summary

Follow-up security and accessibility fixes for the multi-instance dashboard (Issue #6, originally shipped in PR #8).

- **Security**: Bind all 4 dashboard server modes to `127.0.0.1` instead of `0.0.0.0` to prevent unintended network exposure
- **Accessibility**: Add full WAI-ARIA Listbox pattern and keyboard navigation to `ProjectSelector`
- **UX**: Add checkmark icon for selected project (assists colorblind users)

## Changes

### Security — localhost binding (`src/commands/dashboard.mjs`, `bin/startup.sh`)
- `--dev` mode: added `-H 127.0.0.1` to `npm run dev`
- `--serve` mode: added `-H 127.0.0.1` to `npm run start`
- Legacy `serveDashboard()`: changed `.listen()` from `0.0.0.0` to `127.0.0.1`
- `bin/startup.sh`: changed `npx next start -H` from `0.0.0.0` to `127.0.0.1`

### Accessibility — ProjectSelector (`dashboard/src/components/ProjectSelector.tsx`)
- Added `aria-haspopup="listbox"`, `aria-expanded`, `aria-controls` to trigger button
- Added `role="listbox"`, `aria-label`, `aria-activedescendant` to dropdown container
- Added `role="option"`, `aria-selected` to each option with unique IDs
- Full keyboard navigation: ArrowUp/Down, Enter/Space to select, Escape to close, Home/End
- Visible focus ring (`ring-2 ring-inset ring-emerald-500`) on active option
- `scrollIntoView({ block: 'nearest' })` for long project lists
- Focus returns to trigger button on close

### UX — checkmark icon
- Added `Check` icon (lucide-react) next to selected project
- Hidden via `opacity-0`/`opacity-100` to maintain layout alignment

## Test plan

- [x] All 37 existing tests pass (3 suites: routes, data, dashboard command)
- [x] 85 consistency checks pass (pre-push hook)
- [x] Security review: all server binding points verified as `127.0.0.1`
- [x] UX review: ARIA pattern matches WAI-ARIA Listbox specification
- [x] Product review: all acceptance criteria verified

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)