### PR TITLE
fix: correct JSON syntax errors in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "start": "node bin/zapat",
     "test": "node tests/check-consistency.mjs && node tests/check-docs.mjs && npm run test:bats && npm run test:lint",
     "test:lint": "shellcheck bin/*.sh triggers/*.sh lib/*.sh jobs/*.sh 2>/dev/null || echo 'shellcheck not installed — skipping'",
-    "test:shell": "npx bats tests/"
-    "test:bats": "npx bats tests/*.bats",
+    "test:shell": "npx bats tests/",
+    "test:bats": "npx bats tests/*.bats"
   },
   "dependencies": {
     "commander": "^12.0.0"


### PR DESCRIPTION
## Summary
- Fix missing comma after `test:shell` script entry in package.json
- Remove trailing comma after `test:bats` script entry in package.json
- These JSON syntax errors caused `npm install` to fail in CI with `EJSONPARSE`

Closes #24

## Test plan
- [x] Validated JSON parses correctly with `node -e "JSON.parse(...)"`
- [x] Ran `npm install` successfully after fix
- [x] Security review: no new dependencies, no command injection risks
- [x] UX review: script names are clear and consistent
- [x] Product review: fix is minimal and correctly scoped

🤖 Generated with [Claude Code](https://claude.com/claude-code)