### PR TITLE
feat: multi-provider support (OpenAI Codex + Claude)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,11 @@ GH_TOKEN=ghp_YOUR_TOKEN_HERE
 # Leave blank to disable Slack notifications.
 SLACK_WEBHOOK_URL=https://hooks.slack.com/services/YOUR/WEBHOOK/URL
 
+# ─── AI Provider ─────────────────────────────────────────────────────
+# Which AI CLI to use for pipeline tasks. Supported: claude, codex
+# Default: claude
+AGENT_PROVIDER=claude
+
 # ─── Claude / AI Model ───────────────────────────────────────────────
 # Zapat uses a 3-tier model strategy to balance quality and cost:
 #   Lead (CLAUDE_MODEL) > Sub-agents (CLAUDE_SUBAGENT_MODEL) > Utility (CLAUDE_UTILITY_MODEL)
@@ -31,6 +36,12 @@ CLAUDE_SUBAGENT_MODEL=claude-sonnet-4-6
 # Model for utility tasks (test runners, standups, planning) — simple tasks.
 # Used by scheduled jobs and the test runner trigger.
 CLAUDE_UTILITY_MODEL=claude-haiku-4-5-20251001
+
+# ─── Codex / OpenAI Models (when AGENT_PROVIDER=codex) ──────────────
+# These are only used when AGENT_PROVIDER=codex. Ignored when using Claude.
+# CODEX_MODEL=codex
+# CODEX_SUBAGENT_MODEL=codex
+# CODEX_UTILITY_MODEL=codex
 
 # ─── Automation Directory ─────────────────────────────────────────────
 # Auto-detected from script location. Override only if your checkout

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,8 @@
 | `needs-rebase` | Conflicts need manual resolution |
 | `hold` | Block auto-merge |
 | `human-only` | Pipeline should not touch this |
+| `codex` | Process with OpenAI Codex |
+| `claude` | Process with Claude Code |
 
 ## Safety Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,194 +1,50 @@
-# Zapat
+<!-- Slim agent context — full docs in CLAUDE.md at repo root -->
+# Zapat Pipeline Agent Context
 
-Zapat is an autonomous dev pipeline framework powered by Claude Code. It triages GitHub issues, implements features, runs tests, reviews code, and auto-merges -- all triggered by a single label.
-
-## Getting Started
-
-If `.env` does not exist, run `/zapat` (from the repo) or `/zapat:setup` (from the plugin) to configure Zapat for your project.
-
-If already configured, run `/pipeline-check` or `/zapat:pipeline-check` to verify everything is healthy.
-
-## Quick Reference
-
-### Labels
-
-| Label | Description |
-|-------|-------------|
-| `agent` | Let the pipeline handle this (works on issues and PRs) |
-| `agent-work` | Skip triage, implement immediately |
-| `agent-research` | Research and analyze, don't code |
-| `agent-write-tests` | Write tests for the specified code |
-| `hold` | Block auto-merge on this PR |
-| `human-only` | Pipeline should not touch this |
-| `agent-full-review` | Force full team review regardless of complexity |
-
-Status labels are managed automatically by the pipeline:
+## Labels
 
 | Label | Meaning |
 |-------|---------|
+| `agent` | Let the pipeline handle this |
+| `agent-work` | Implementation task |
+| `agent-research` | Research and analyze |
+| `agent-write-tests` | Write tests |
 | `zapat-triaging` | Triage in progress |
 | `zapat-implementing` | Implementation in progress |
-| `zapat-review` | Code review pending |
+| `zapat-review` | Review pending |
 | `zapat-testing` | Tests running |
 | `zapat-rework` | Addressing review feedback |
-| `needs-rebase` | Auto-rebase failed due to conflicts (manual resolution needed) |
+| `needs-rebase` | Conflicts need manual resolution |
+| `hold` | Block auto-merge |
+| `human-only` | Pipeline should not touch this |
 
-### CLI Commands
+## Safety Rules
 
-| Command | Description |
-|---------|-------------|
-| `bin/zapat status` | Pipeline overview (active sessions, recent jobs, success rate) |
-| `bin/zapat health` | Run health checks on all pipeline components |
-| `bin/zapat health --auto-fix` | Auto-repair common issues (orphaned worktrees, stale slots) |
-| `bin/zapat metrics query --days 7` | Query job metrics for the last N days |
-| `bin/zapat risk REPO PR_NUM` | Classify risk level of a pull request |
-| `bin/zapat dashboard` | Launch the Next.js monitoring dashboard |
-| `bin/zapat logs rotate` | Rotate and compress old log files |
+- Never commit secrets, credentials, or .env files
+- Never force-push to main
+- Always create feature branches from main
+- Run tests before marking implementation complete
+- Never modify files outside the working directory
 
-### Skills (project-scoped)
+## Key Paths
 
-| Skill | Description |
-|-------|-------------|
-| `/zapat` | Configure Zapat for your project (interactive wizard) |
-| `/add-repo` | Add a new repository to monitor |
-| `/pipeline-check` | Quick health check with plain-language results |
+- Repos: `config/repos.conf`
+- Agents: `config/agents.conf`
+- Prompts: `prompts/`
+- Triggers: `triggers/`
+- Shared libs: `lib/`
 
-### Skills (plugin — available globally after `claude plugin install`)
+## Agent Memory
 
-| Skill | Description |
-|-------|-------------|
-| `/zapat:setup` | Configure Zapat for your project (interactive wizard) |
-| `/zapat:add-repo` | Add a new repository to monitor |
-| `/zapat:pipeline-check` | Quick health check with plain-language results |
+Shared knowledge: `~/.claude/agent-memory/_shared/`
+- `DECISIONS.md` — architectural decisions
+- `CODEBASE.md` — cross-repo patterns
+- `PIPELINE.md` — pipeline state and known issues
 
 ## Architecture
 
 ```
-GitHub Issue (labeled) --> Poller (every 2 min) --> Trigger Script --> Claude Code Agent Team --> PR --> Review Agent Team --> Auto-Merge Gate
+GitHub Issue (labeled) --> Poller --> Trigger Script --> Claude Code Agent Team --> PR --> Review Agent --> Auto-Merge
 ```
 
-**Flow:**
-1. The cron-based poller (`bin/poll-github.sh`) scans configured repos for issues/PRs with pipeline labels.
-2. When found, it dispatches the appropriate trigger script (`triggers/on-new-issue.sh`, `triggers/on-work-issue.sh`, etc.) in a background tmux session.
-3. The trigger script fetches `origin/main` and creates an isolated worktree under `~/.zapat/worktrees/` before launching agents, ensuring they always see the latest code.
-4. All job types (triage, review, research, implementation, rework) run in isolated git worktrees — never touching the user's main checkout. Implementation worktrees create PRs; read-only worktrees are cleaned up after the session.
-5. The auto-merge gate evaluates risk (low/medium/high) and merges if all checks pass.
-6. When a PR merges and `main` moves forward, the auto-rebase system detects stale `agent/*` PRs and rebases them automatically. On conflict, it adds the `needs-rebase` label and posts details.
-
-**Key directories:**
-
-| Directory | Purpose |
-|-----------|---------|
-| `bin/` | Pipeline CLI and core scripts (poller, startup, notifications) |
-| `triggers/` | Event handlers that launch agent teams |
-| `prompts/` | Prompt templates for each job type |
-| `agents/` | Agent persona definitions (copied to `~/.claude/agents/`) |
-| `lib/` | Shared shell libraries (state machine, tmux helpers, common utilities) |
-| `src/` | Node.js source for the pipeline CLI |
-| `config/` | Repository and agent configuration |
-| `dashboard/` | Next.js monitoring dashboard |
-| `state/` | Runtime state (items, slots, locks, PIDs) |
-| `logs/` | Job logs and structured metrics |
-| `data/` | Metrics data (JSONL) |
-
-## Agent Team Recipes
-
-Every task uses a team of specialized agents. The roles are defined in `config/agents.conf` and map to persona files in `agents/`.
-
-### Implementation Team
-When implementing a feature (`agent-work` label):
-- **builder** (from agents.conf) -- reads the codebase, implements the feature, writes tests
-- **security** (from agents.conf) -- reviews for vulnerabilities, auth issues, injection risks
-- **product** (from agents.conf) -- validates the implementation meets requirements
-- **ux** (from agents.conf) -- reviews user-facing changes for usability
-
-### Code Review Team
-When reviewing a PR (`agent` label on PR):
-- **security** -- security-focused review
-- **builder** -- code quality, architecture, test coverage
-- **ux** -- UX implications of the changes
-
-### Research Team
-When investigating a topic (`agent-research` label):
-- **product** -- defines research scope and success criteria
-- **builder** -- technical investigation and feasibility
-- **security** -- security implications and risks
-
-### Triage Team
-When triaging a new issue (`agent` label):
-- All four core roles collaborate to assess complexity, priority, security concerns, and recommended approach.
-
-### Bug Investigation Team
-When debugging a complex issue, spin up parallel hypothesis investigators:
-- **hypothesis-1** (builder) -- investigate theory A (e.g., frontend rendering)
-- **hypothesis-2** (builder) -- investigate theory B (e.g., backend API response)
-- **hypothesis-3** (security) -- investigate theory C (e.g., auth/session issue)
-Each investigates independently, shares findings, and tries to disprove each other's theories.
-
-### Full-Stack Feature Team
-When a feature spans backend + frontend (or multiple repos):
-- **backend-engineer** (builder) -- builds API endpoints, database changes
-- **frontend-engineer** (builder) -- consumes the API from the web/mobile app
-- **security** -- reviews the entire data flow end-to-end
-- **product** -- validates the feature meets requirements across layers
-Assign different repos to different agents to avoid file conflicts. Backend builds the API first and shares the contract.
-
-## Troubleshooting
-
-**Nothing happens after labeling an issue:**
-```bash
-bin/zapat health          # Check for issues
-bin/zapat status          # Verify poller is running
-tail -20 logs/cron-poll.log  # Check poller logs
-```
-
-**Agent session timed out:**
-Check the job log in `logs/`. The item will auto-retry with exponential backoff (10 min, 30 min, then abandon).
-
-**Orphaned worktrees or stale slots:**
-```bash
-bin/zapat health --auto-fix
-```
-This also runs automatically every poll cycle.
-
-**Dashboard not loading:**
-```bash
-lsof -i :8080              # Check if process is running
-bin/startup.sh             # Restart everything
-```
-
-**GitHub auth errors:**
-```bash
-gh auth status             # Check current auth
-gh auth login              # Re-authenticate
-```
-
-## Customization
-
-### Adding repositories
-Edit `config/repos.conf` or run the `/add-repo` skill. Format: `owner/repo<TAB>local_path<TAB>type`.
-
-### Adding agent personas
-1. Create a `.md` file in `agents/` following the format of existing personas.
-2. Add a role mapping in `config/agents.conf` (e.g., `compliance=healthcare-advisor`).
-3. Run `cp agents/*.md ~/.claude/agents/` to deploy.
-
-### Modifying prompts
-Edit files in `prompts/`. Templates use `{{PLACEHOLDER}}` syntax that gets substituted at runtime by `lib/common.sh`. Available placeholders include `{{REPO}}`, `{{ISSUE_NUMBER}}`, `{{PR_NUMBER}}`, `{{BRANCH}}`, and others. Common repository map and safety rules are auto-appended from `prompts/_shared-footer.txt`.
-
-### Enabling compliance mode
-Set `ENABLE_COMPLIANCE_MODE=true` in `.env` and add a compliance agent persona:
-1. Create `agents/compliance-advisor.md` with domain-specific rules.
-2. Add `compliance=compliance-advisor` to `config/agents.conf`.
-3. The pipeline will consult the compliance persona during reviews and before auto-merge.
-
-### Prompt Caching
-Claude Code automatically caches static system prompt prefixes (CLAUDE.md + agent personas) between turns. The shared footer (`prompts/_shared-footer.txt`) improves cacheability by ensuring common content is consistent across templates. No additional configuration is needed -- caching is handled by the Claude Code runtime. No `cache_creation_input_tokens` metrics are currently tracked in logs.
-
-### Shared agent memory
-Agents share knowledge via files in `~/.claude/agent-memory/_shared/`:
-- `DECISIONS.md` -- architectural decisions agents should follow
-- `CODEBASE.md` -- cross-repo patterns and conventions
-- `PIPELINE.md` -- pipeline state and known issues
-
-Edit these files to give agents persistent context about your project.
+All jobs run in isolated git worktrees under `~/.zapat/worktrees/`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,3 +50,17 @@ GitHub Issue (labeled) --> Poller --> Trigger Script --> Claude Code Agent Team 
 ```
 
 All jobs run in isolated git worktrees under `~/.zapat/worktrees/`.
+
+## Multi-PR Feature Branches
+
+For large features spanning multiple sub-issues, use a feature branch workflow:
+
+1. Create a feature branch from `main` (e.g., `feature/multi-provider-support`)
+2. Sub-PRs target the **feature branch**, not `main`
+3. Add `hold` label to sub-PRs to prevent auto-merge (auto-merge gate only merges PRs targeting `main`)
+4. Human merges sub-PRs into the feature branch manually
+5. Once all sub-PRs are merged, rebase the feature branch onto `main`
+6. Open a single integration PR from the feature branch to `main`
+7. The integration PR gets the full pipeline treatment (triage, review, test, auto-merge)
+
+**Important**: Never let the pipeline auto-merge sub-PRs targeting feature branches. The auto-merge gate skips PRs not targeting `main` by design.

--- a/agents/devops-engineer.md
+++ b/agents/devops-engineer.md
@@ -4,50 +4,46 @@ permissionMode: bypassPermissions
 ---
 # DevOps Engineer
 
-You are a world-class DevOps and infrastructure engineer with deep expertise in CI/CD pipelines, deployment automation, infrastructure-as-code, and system reliability. You think in terms of automation, reproducibility, and operational excellence.
+You are a world-class DevOps and infrastructure engineer with deep expertise in CI/CD, deployment automation, IaC, and system reliability.
 
 ## Core Expertise
-- **CI/CD Pipelines**: Designing and maintaining GitHub Actions, build pipelines, and deployment workflows
-- **Infrastructure-as-Code**: Terraform, CloudFormation, CDK, Docker, and container orchestration
-- **Shell Scripting**: Writing robust, portable Bash scripts with proper error handling
-- **Monitoring & Observability**: Logging, alerting, health checks, and incident response
-- **Release Engineering**: Versioning, changelogs, rollback strategies, and deployment safety
-- **Security Hardening**: Least-privilege IAM, secrets management, network security, supply chain security
+- **CI/CD**: GitHub Actions, build pipelines, deployment workflows
+- **IaC**: Terraform, CloudFormation, CDK, Docker, container orchestration
+- **Shell Scripting**: Robust, portable Bash with proper error handling
+- **Observability**: Logging, alerting, health checks, incident response
+- **Release Engineering**: Versioning, changelogs, rollback strategies
+- **Security Hardening**: Least-privilege IAM, secrets management, supply chain security
 
 ## Working Style
 - Automate everything that runs more than twice
-- Write scripts that fail loudly and early — use `set -euo pipefail` by default
-- Design for idempotency — running something twice should produce the same result
+- Use `set -euo pipefail` by default — fail loudly and early
+- Design for idempotency — running twice produces the same result
 - Prefer declarative over imperative configuration
-- Document operational runbooks for anything that can't be fully automated
-- Test infrastructure changes in isolation before applying to production
+- Test infrastructure changes in isolation before production
 
 ## Review Methodology
-When reviewing PRs that touch infra, CI/CD, or scripts:
-1. **Reliability**: Will this work consistently? What happens on failure? Is there retry logic?
-2. **Security**: Are secrets handled properly? Least privilege? No credentials in code?
-3. **Portability**: Will this work across environments (CI, local dev, different OS)?
-4. **Idempotency**: Can this be run multiple times safely?
-5. **Rollback**: If this goes wrong, how do we recover?
-6. **Performance**: Will this slow down the pipeline? Are there unnecessary steps?
+When reviewing infra, CI/CD, or script PRs:
+1. **Reliability**: Consistent behavior? Failure handling? Retry logic?
+2. **Security**: Secrets handled properly? Least privilege? No creds in code?
+3. **Portability**: Works across CI, local dev, different OS?
+4. **Idempotency**: Safe to run multiple times?
+5. **Rollback**: Recovery plan if it goes wrong?
+6. **Performance**: Pipeline impact? Unnecessary steps?
 
 ## Knowing Your Limits
-- If a task involves application-level architecture or business logic, defer to the engineer agent
-- If you're unfamiliar with a specific cloud provider, managed service, or deployment target, say so and recommend consulting relevant documentation or a specialist
-- If a security concern goes beyond infrastructure hardening (e.g., application-level vulnerabilities, cryptographic design), escalate to the security reviewer
-- Do not guess at infrastructure costs or scaling behavior — flag it for human review if estimates are critical
+- Defer app-level architecture/business logic to the engineer agent
+- If unfamiliar with a cloud provider or service, say so
+- Escalate app-level security (crypto design, vulns) to the security reviewer
+- Don't guess infra costs or scaling — flag for human review
 
 ## Output Format
-For infrastructure reviews:
-- **Issue**: What's the problem?
-- **Risk**: What could go wrong in production?
-- **Fix**: Specific remediation with code/config examples
+For infra reviews: **Issue** → **Risk** → **Fix** (with code examples)
 
 For pipeline changes:
-1. **Change Summary**: What's being modified and why?
-2. **Impact Assessment**: What environments/workflows are affected?
-3. **Rollback Plan**: How to revert if something goes wrong
-4. **Testing**: How was this validated?
+1. **Change Summary**: What and why
+2. **Impact**: Affected environments/workflows
+3. **Rollback Plan**: How to revert
+4. **Testing**: How it was validated
 
 ## Context
 Consult the shared memory at ~/.claude/agent-memory/_shared/ for:

--- a/agents/qa-engineer.md
+++ b/agents/qa-engineer.md
@@ -4,49 +4,42 @@ permissionMode: bypassPermissions
 ---
 # QA Engineer
 
-You are a world-class quality assurance engineer with deep expertise in test strategy, test automation, and defect analysis. You think adversarially — your job is to find the bugs that others miss by exploring edge cases, boundary conditions, race conditions, and failure modes that developers don't anticipate.
+You are a world-class QA engineer. You think adversarially — finding bugs others miss by exploring edge cases, boundary conditions, race conditions, and unexpected failure modes.
 
 ## Core Expertise
-- **Test Strategy**: Designing comprehensive test plans that maximize coverage with minimal redundancy
-- **Test Automation**: Writing reliable, maintainable automated tests (unit, integration, e2e)
-- **Edge Case Analysis**: Systematically identifying boundary conditions, null cases, concurrency issues, and unexpected input combinations
-- **Regression Prevention**: Ensuring changes don't break existing functionality
-- **Test Infrastructure**: Setting up and maintaining test frameworks, CI test pipelines, and test data management
+- **Test Strategy**: Maximize coverage with minimal redundancy
+- **Test Automation**: Reliable unit, integration, and e2e tests
+- **Edge Case Analysis**: Boundary conditions, null cases, concurrency issues
+- **Regression Prevention**: Changes don't break existing functionality
+- **Test Infrastructure**: Frameworks, CI pipelines, test data management
 
 ## Working Style
-- Read the code under test thoroughly before writing any test
-- Prioritize testing the riskiest paths first — not just the happy path
-- Write tests that are independent, deterministic, and fast
-- Use descriptive test names that explain the scenario and expected behavior
-- Keep test code as clean and maintainable as production code
-- Prefer real assertions over snapshot tests when behavior is well-defined
+- Read code under test thoroughly before writing tests
+- Prioritize riskiest paths first, not just happy path
+- Tests must be independent, deterministic, and fast
+- Descriptive test names explaining scenario and expected behavior
+- Prefer real assertions over snapshots when behavior is defined
 
 ## Review Methodology
-When reviewing PRs:
-1. **Coverage Gap Analysis**: What code paths have no tests? What edge cases are missing?
-2. **Test Quality**: Are existing tests actually testing meaningful behavior, or just asserting trivia?
-3. **Regression Risk**: Could this change break something that isn't tested?
-4. **Flakiness Risk**: Could any new test be non-deterministic (timing, ordering, external deps)?
-5. **Test Data**: Are test fixtures realistic? Do they cover representative scenarios?
+1. **Coverage Gaps**: Untested code paths? Missing edge cases?
+2. **Test Quality**: Testing meaningful behavior or just trivia?
+3. **Regression Risk**: Could this break something untested?
+4. **Flakiness Risk**: Non-deterministic tests (timing, ordering)?
+5. **Test Data**: Fixtures realistic and representative?
 
 ## Knowing Your Limits
-- If you encounter a tech stack or framework you're not deeply experienced with, say so explicitly and recommend consulting the engineer or relevant documentation
-- If a domain requires specialized knowledge (e.g., cryptographic testing, hardware-specific behavior, compliance validation), flag it and ask for domain expert input
-- Do not guess at expected behavior — if requirements are ambiguous, ask for clarification before writing tests
-- If test infrastructure or CI setup is beyond your scope, escalate to the devops agent
+- Unfamiliar stack/framework? Say so, recommend consulting docs
+- Don't guess expected behavior — ask for clarification first
+- Escalate CI/infra setup to the devops agent
 
 ## Output Format
-For test reviews:
-- **Gap**: What's not tested?
-- **Risk**: What could break?
-- **Recommendation**: Specific test to add, with example code
+For test reviews: **Gap** → **Risk** → **Recommendation** (with example code)
 
 For test plans:
-1. **Scope**: What are we testing and why?
-2. **Strategy**: Unit vs integration vs e2e breakdown
-3. **Priority Cases**: Ranked list of scenarios to test
-4. **Edge Cases**: Boundary conditions and failure modes
-5. **Dependencies**: What test infrastructure is needed?
+1. **Scope**: What and why
+2. **Strategy**: Unit vs integration vs e2e
+3. **Priority Cases**: Ranked scenarios
+4. **Edge Cases**: Boundaries and failure modes
 
 ## Context
 Consult the shared memory at ~/.claude/agent-memory/_shared/ for:

--- a/agents/technical-writer.md
+++ b/agents/technical-writer.md
@@ -4,55 +4,49 @@ permissionMode: bypassPermissions
 ---
 # Technical Writer
 
-You are a world-class technical writer with deep expertise in developer documentation, API references, and open-source project communication. You write docs that developers actually read — concise, scannable, example-driven, and always accurate against the current codebase.
+You are a world-class technical writer. You write docs developers actually read — concise, scannable, example-driven, and accurate against the current codebase.
 
 ## Core Expertise
-- **Developer Documentation**: READMEs, getting-started guides, architecture overviews, and contribution guides
-- **API Documentation**: Endpoint references, request/response examples, error codes, and authentication flows
-- **Changelog Management**: Writing clear, user-facing changelogs that explain what changed and why it matters
-- **Code Comments**: Writing inline documentation that explains "why," not "what"
-- **Information Architecture**: Organizing docs so users find what they need in under 30 seconds
+- **Developer Docs**: READMEs, getting-started guides, architecture overviews
+- **API Docs**: Endpoint references, request/response examples, error codes
+- **Changelogs**: Clear, user-facing entries explaining what changed and why
+- **Code Comments**: Explains "why," not "what"
+- **Information Architecture**: Users find what they need in under 30 seconds
 
 ## Writing Principles
-1. **Accuracy first** — Every code example must work. Every command must be copy-pasteable. Always verify against the actual codebase before writing.
-2. **Show, don't tell** — Lead with examples. A working code snippet is worth a paragraph of explanation.
-3. **Concise by default** — If a sentence doesn't add information, delete it. Developers skim.
-4. **Progressive depth** — Start with the simplest case. Layer in complexity for readers who need it.
-5. **Keep it current** — Stale docs are worse than no docs. Always check if existing docs need updating when code changes.
+1. **Accuracy first** — Every example must work. Every command copy-pasteable.
+2. **Show, don't tell** — Lead with examples over explanation.
+3. **Concise** — Delete sentences that don't add information.
+4. **Progressive depth** — Simplest case first, then layer complexity.
+5. **Keep current** — Stale docs are worse than no docs.
 
 ## Working Style
-- Always read the relevant source code before writing or updating docs
-- Verify every code example compiles/runs before including it
-- Follow the project's existing doc style and structure
-- Update the CHANGELOG for user-facing changes
-- Keep README focused — link to detailed docs instead of bloating it
-- Use consistent terminology — define terms once, reuse everywhere
+- Read source code before writing or updating docs
+- Verify every code example compiles/runs
+- Follow the project's existing doc style
+- Update CHANGELOG for user-facing changes
+- Use consistent terminology throughout
 
 ## Review Methodology
-When reviewing PRs for documentation impact:
-1. **Doc Drift**: Does this code change make any existing documentation incorrect?
-2. **Missing Docs**: Does this new feature/API need documentation that doesn't exist yet?
-3. **Changelog**: Should this change be mentioned in the CHANGELOG?
-4. **Examples**: Are existing examples still accurate after this change?
-5. **Error Messages**: Are user-facing error messages clear and actionable?
+1. **Doc Drift**: Does this code change make existing docs incorrect?
+2. **Missing Docs**: Does this feature need docs that don't exist?
+3. **Changelog**: Should this change be in the CHANGELOG?
+4. **Examples**: Are existing examples still accurate?
+5. **Error Messages**: Are user-facing errors clear and actionable?
 
 ## Knowing Your Limits
-- If you're unsure about the intended behavior of a feature, ask the engineer or product manager before documenting it — don't guess
-- If a topic requires deep domain expertise (e.g., cryptography, compliance, specific cloud services), flag it and ask the relevant specialist to review your draft
-- If the documentation structure needs a major overhaul, propose the new structure and get approval before rewriting
-- Do not make code changes beyond documentation files unless explicitly asked
+- Don't guess at intended behavior — ask the engineer or PM first
+- Flag topics needing domain expertise for specialist review
+- Don't make code changes beyond doc files unless asked
 
 ## Output Format
-For doc reviews:
-- **Issue**: What's inaccurate, missing, or confusing?
-- **Location**: File path and section
-- **Fix**: Specific text to add, update, or remove
+For doc reviews: **Issue** → **Location** → **Fix** (specific text)
 
-For new documentation:
-1. **Purpose**: What question does this doc answer?
-2. **Audience**: Who is this for? (new user, contributor, operator)
-3. **Content**: The documentation itself
-4. **Placement**: Where this fits in the existing doc structure
+For new docs:
+1. **Purpose**: What question does this answer?
+2. **Audience**: New user, contributor, or operator?
+3. **Content**: The documentation
+4. **Placement**: Where it fits in existing structure
 
 ## Context
 Consult the shared memory at ~/.claude/agent-memory/_shared/ for:

--- a/bin/poll-github.sh
+++ b/bin/poll-github.sh
@@ -1064,7 +1064,7 @@ while IFS= read -r state_file; do
     set_project "$item_project"
 
     # Detect provider from item labels
-    local retry_labels=""
+    retry_labels=""
     case "$item_type" in
         pr|rework|test)
             retry_labels=$(gh pr view "$item_number" --repo "$item_repo" --json labels \

--- a/bin/poll-github.sh
+++ b/bin/poll-github.sh
@@ -171,6 +171,49 @@ should_process() {
     return 0
 }
 
+# --- Provider Label Detection ---
+# Reads labels (JSON array or comma-separated string) and sets AGENT_PROVIDER.
+# Priority: claude label wins if both present (with warning).
+# Falls back to AGENT_PROVIDER from .env (default: claude).
+# Usage: detect_provider_label "$LABELS_JSON_OR_CSV"
+# Side-effect: exports AGENT_PROVIDER
+detect_provider_label() {
+    local labels="$1"
+    local has_codex=false
+    local has_claude=false
+
+    # Detect format: JSON array starts with '[', otherwise treat as CSV
+    if [[ "$labels" == "["* ]]; then
+        # JSON array of label objects (e.g., [{"name":"codex"}, ...])
+        if echo "$labels" | jq -e '.[] | select(.name == "codex")' &>/dev/null; then
+            has_codex=true
+        fi
+        if echo "$labels" | jq -e '.[] | select(.name == "claude")' &>/dev/null; then
+            has_claude=true
+        fi
+    else
+        # Comma-separated string (e.g., "agent-work,codex,feature")
+        if echo ",$labels," | grep -q ",codex,"; then
+            has_codex=true
+        fi
+        if echo ",$labels," | grep -q ",claude,"; then
+            has_claude=true
+        fi
+    fi
+
+    if [[ "$has_claude" == "true" && "$has_codex" == "true" ]]; then
+        log_warn "Conflicting provider labels: both 'codex' and 'claude' present — preferring claude"
+        export AGENT_PROVIDER="claude"
+    elif [[ "$has_codex" == "true" ]]; then
+        export AGENT_PROVIDER="codex"
+    elif [[ "$has_claude" == "true" ]]; then
+        export AGENT_PROVIDER="claude"
+    else
+        # Fall back to .env default (already loaded by load_env)
+        export AGENT_PROVIDER="${AGENT_PROVIDER:-claude}"
+    fi
+}
+
 # --- Dependency Check ---
 # Returns 0 if all "Blocked By" dependencies are closed, 1 if still blocked
 check_dependencies() {
@@ -296,6 +339,7 @@ scan_mentions() {
             pr_labels=$(gh pr view "$item_number" --repo "$repo" --json labels \
                 --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
 
+            detect_provider_label "$pr_labels"
             if echo "$pr_labels" | grep -q "zapat-rework"; then
                 "$SCRIPT_DIR/triggers/on-rework-pr.sh" "$repo" "$item_number" "$mention_text" "$cur_project" &
             elif echo "$pr_labels" | grep -q "zapat-testing"; then
@@ -309,6 +353,8 @@ scan_mentions() {
             local issue_labels
             issue_labels=$(gh issue view "$item_number" --repo "$repo" --json labels \
                 --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
+
+            detect_provider_label "$issue_labels"
 
             if echo "$issue_labels" | grep -q "agent-research"; then
                 "$SCRIPT_DIR/triggers/on-research-issue.sh" "$repo" "$item_number" "$mention_text" "$cur_project" &
@@ -430,7 +476,8 @@ while IFS=$'\t' read -r repo local_path repo_type; do
 
         TOTAL_ITEMS_FOUND=$((TOTAL_ITEMS_FOUND + 1))
         dispatch_limit_reached && continue
-        log_info "Processing PR: $PR_KEY — $PR_TITLE (project: $project_slug)"
+        detect_provider_label "$PR_LABELS"
+        log_info "Processing PR: $PR_KEY — $PR_TITLE (project: $project_slug, provider: $AGENT_PROVIDER)"
         create_item_state "$repo" "pr" "$PR_NUM" "pending" "$project_slug" || true
         "$SCRIPT_DIR/triggers/on-new-pr.sh" "$repo" "$PR_NUM" "" "$project_slug" &
         echo "$PR_KEY" >> "$PROCESSED_PRS"
@@ -466,7 +513,8 @@ while IFS=$'\t' read -r repo local_path repo_type; do
 
         TOTAL_ITEMS_FOUND=$((TOTAL_ITEMS_FOUND + 1))
         dispatch_limit_reached && continue
-        log_info "Processing zapat-review: $REVIEW_KEY — $REVIEW_TITLE (project: $project_slug)"
+        detect_provider_label "$REVIEW_LABELS"
+        log_info "Processing zapat-review: $REVIEW_KEY — $REVIEW_TITLE (project: $project_slug, provider: $AGENT_PROVIDER)"
         create_item_state "$repo" "pr" "$REVIEW_NUM" "pending" "$project_slug" || true
         "$SCRIPT_DIR/triggers/on-new-pr.sh" "$repo" "$REVIEW_NUM" "" "$project_slug" &
         echo "$REVIEW_KEY" >> "$PROCESSED_PRS"
@@ -502,7 +550,8 @@ while IFS=$'\t' read -r repo local_path repo_type; do
 
         TOTAL_ITEMS_FOUND=$((TOTAL_ITEMS_FOUND + 1))
         dispatch_limit_reached && continue
-        log_info "Processing issue: $ISSUE_KEY — $ISSUE_TITLE (project: $project_slug)"
+        detect_provider_label "$ISSUE_LABELS"
+        log_info "Processing issue: $ISSUE_KEY — $ISSUE_TITLE (project: $project_slug, provider: $AGENT_PROVIDER)"
         create_item_state "$repo" "issue" "$ISSUE_NUM" "pending" "$project_slug" || true
         "$SCRIPT_DIR/triggers/on-new-issue.sh" "$repo" "$ISSUE_NUM" "" "$project_slug" &
         echo "$ISSUE_KEY" >> "$PROCESSED_ISSUES"
@@ -544,7 +593,8 @@ while IFS=$'\t' read -r repo local_path repo_type; do
 
         TOTAL_ITEMS_FOUND=$((TOTAL_ITEMS_FOUND + 1))
         dispatch_limit_reached && continue
-        log_info "Processing agent-work: $WORK_KEY — $WORK_TITLE (project: $project_slug)"
+        detect_provider_label "$WORK_LABELS"
+        log_info "Processing agent-work: $WORK_KEY — $WORK_TITLE (project: $project_slug, provider: $AGENT_PROVIDER)"
         create_item_state "$repo" "work" "$WORK_NUM" "pending" "$project_slug" || true
         "$SCRIPT_DIR/triggers/on-work-issue.sh" "$repo" "$WORK_NUM" "" "$project_slug" &
         echo "$WORK_KEY" >> "$PROCESSED_WORK"
@@ -580,7 +630,8 @@ while IFS=$'\t' read -r repo local_path repo_type; do
 
         TOTAL_ITEMS_FOUND=$((TOTAL_ITEMS_FOUND + 1))
         dispatch_limit_reached && continue
-        log_info "Processing zapat-rework: $REWORK_KEY — $REWORK_TITLE (project: $project_slug)"
+        detect_provider_label "$REWORK_LABELS"
+        log_info "Processing zapat-rework: $REWORK_KEY — $REWORK_TITLE (project: $project_slug, provider: $AGENT_PROVIDER)"
         create_item_state "$repo" "rework" "$REWORK_NUM" "pending" "$project_slug" || true
         "$SCRIPT_DIR/triggers/on-rework-pr.sh" "$repo" "$REWORK_NUM" "" "$project_slug" &
         echo "$REWORK_KEY" >> "$PROCESSED_REWORK"
@@ -615,7 +666,8 @@ while IFS=$'\t' read -r repo local_path repo_type; do
 
         TOTAL_ITEMS_FOUND=$((TOTAL_ITEMS_FOUND + 1))
         dispatch_limit_reached && continue
-        log_info "Processing zapat-testing: $TEST_KEY — $TEST_TITLE (project: $project_slug)"
+        detect_provider_label "$TEST_LABELS"
+        log_info "Processing zapat-testing: $TEST_KEY — $TEST_TITLE (project: $project_slug, provider: $AGENT_PROVIDER)"
         create_item_state "$repo" "test" "$TEST_NUM" "pending" "$project_slug" >/dev/null || true
         "$SCRIPT_DIR/triggers/on-test-pr.sh" "$repo" "$TEST_NUM" "" "$project_slug" &
         echo "$TEST_KEY" >> "$PROCESSED_TESTING"
@@ -651,7 +703,8 @@ while IFS=$'\t' read -r repo local_path repo_type; do
 
         TOTAL_ITEMS_FOUND=$((TOTAL_ITEMS_FOUND + 1))
         dispatch_limit_reached && continue
-        log_info "Processing agent-write-tests: $WT_KEY — $WT_TITLE (project: $project_slug)"
+        detect_provider_label "$WT_LABELS"
+        log_info "Processing agent-write-tests: $WT_KEY — $WT_TITLE (project: $project_slug, provider: $AGENT_PROVIDER)"
         create_item_state "$repo" "write-tests" "$WT_NUM" "pending" "$project_slug" || true
         "$SCRIPT_DIR/triggers/on-write-tests.sh" "$repo" "$WT_NUM" "" "$project_slug" &
         echo "$WT_KEY" >> "$PROCESSED_WRITE_TESTS"
@@ -687,7 +740,8 @@ while IFS=$'\t' read -r repo local_path repo_type; do
 
         TOTAL_ITEMS_FOUND=$((TOTAL_ITEMS_FOUND + 1))
         dispatch_limit_reached && continue
-        log_info "Processing agent-research: $RESEARCH_KEY — $RESEARCH_TITLE (project: $project_slug)"
+        detect_provider_label "$RESEARCH_LABELS"
+        log_info "Processing agent-research: $RESEARCH_KEY — $RESEARCH_TITLE (project: $project_slug, provider: $AGENT_PROVIDER)"
         create_item_state "$repo" "research" "$RESEARCH_NUM" "pending" "$project_slug" || true
         "$SCRIPT_DIR/triggers/on-research-issue.sh" "$repo" "$RESEARCH_NUM" "" "$project_slug" &
         echo "$RESEARCH_KEY" >> "$PROCESSED_RESEARCH"
@@ -757,7 +811,8 @@ while IFS=$'\t' read -r repo local_path repo_type; do
 
             TOTAL_ITEMS_FOUND=$((TOTAL_ITEMS_FOUND + 1))
             dispatch_limit_reached && continue
-            log_info "Auto-triage: new issue $AT_KEY — $AT_TITLE (project: $project_slug)"
+            detect_provider_label "$AT_LABELS"
+            log_info "Auto-triage: new issue $AT_KEY — $AT_TITLE (project: $project_slug, provider: $AGENT_PROVIDER)"
             create_item_state "$repo" "issue" "$AT_NUM" "pending" "$project_slug" || true
             "$SCRIPT_DIR/triggers/on-new-issue.sh" "$repo" "$AT_NUM" "" "$project_slug" &
             echo "$AT_KEY" >> "$PROCESSED_AUTO_TRIAGE"
@@ -983,7 +1038,19 @@ while IFS= read -r state_file; do
     # Activate the item's project before dispatching
     set_project "$item_project"
 
-    log_info "Retrying $item_type #$item_number in $item_repo (project: $item_project)"
+    # Detect provider from item labels
+    local retry_labels=""
+    case "$item_type" in
+        pr|rework|test)
+            retry_labels=$(gh pr view "$item_number" --repo "$item_repo" --json labels \
+                --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "") ;;
+        *)
+            retry_labels=$(gh issue view "$item_number" --repo "$item_repo" --json labels \
+                --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "") ;;
+    esac
+    detect_provider_label "$retry_labels"
+
+    log_info "Retrying $item_type #$item_number in $item_repo (project: $item_project, provider: $AGENT_PROVIDER)"
     update_item_state "$state_file" "running"
 
     case "$item_type" in

--- a/bin/setup-labels.sh
+++ b/bin/setup-labels.sh
@@ -30,6 +30,9 @@ LABELS=(
     "hold|B60205|Block auto-merge on this PR"
     "human-only|E4E669|Pipeline should not touch this item"
     "agent-full-review|1D76DB|Force full team review regardless of complexity"
+    # Provider selection
+    "codex|74AA9C|Process with OpenAI Codex"
+    "claude|D97706|Process with Claude Code"
     # Tier 3 — Internal/status
     "zapat-triaging|CCCCCC|Triage in progress"
     "zapat-implementing|CCCCCC|Implementation in progress"

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -725,6 +725,8 @@ $(cat "$footer_file")"
     # AGENT_PROVIDER is canonical (set by lib/provider.sh + poll-github.sh routing)
     # PROVIDER accepted as alias for backward compatibility
     local _provider="${AGENT_PROVIDER:-${PROVIDER:-claude}}"
+    # Normalize to lowercase before sanitizing (prevents "Claude" → "laude")
+    _provider=$(printf '%s' "$_provider" | tr '[:upper:]' '[:lower:]')
     # Sanitize provider name to prevent path traversal (only allow [a-z0-9_-])
     _provider="${_provider//[^a-z0-9_-]/}"
     [[ -z "$_provider" ]] && _provider="claude"
@@ -780,6 +782,8 @@ Showing first ~${shown_lines} lines of ${total_lines} total lines (~${max_diff_c
         while [[ "$content" == *'{{#IF_CODEX}}'* ]]; do
             local before="${content%%\{\{#IF_CODEX\}\}*}"
             local after="${content#*\{\{/IF_CODEX\}\}}"
+            # Guard against unclosed tags (no matching close → infinite loop)
+            [[ "$after" == "$content" ]] && break
             content="${before}${after}"
         done
         # Unwrap {{#IF_CLAUDE}}...{{/IF_CLAUDE}} blocks (remove tags, keep content)
@@ -790,6 +794,8 @@ Showing first ~${shown_lines} lines of ${total_lines} total lines (~${max_diff_c
         while [[ "$content" == *'{{#IF_CLAUDE}}'* ]]; do
             local before="${content%%\{\{#IF_CLAUDE\}\}*}"
             local after="${content#*\{\{/IF_CLAUDE\}\}}"
+            # Guard against unclosed tags (no matching close → infinite loop)
+            [[ "$after" == "$content" ]] && break
             content="${before}${after}"
         done
         # Unwrap {{#IF_CODEX}}...{{/IF_CODEX}} blocks (remove tags, keep content)

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -725,6 +725,9 @@ $(cat "$footer_file")"
     # AGENT_PROVIDER is canonical (set by lib/provider.sh + poll-github.sh routing)
     # PROVIDER accepted as alias for backward compatibility
     local _provider="${AGENT_PROVIDER:-${PROVIDER:-claude}}"
+    # Sanitize provider name to prevent path traversal (only allow [a-z0-9_-])
+    _provider="${_provider//[^a-z0-9_-]/}"
+    [[ -z "$_provider" ]] && _provider="claude"
 
     # For Codex provider, use Codex model name instead of Claude's
     if [[ "$_provider" == "codex" ]]; then
@@ -782,7 +785,7 @@ Showing first ~${shown_lines} lines of ${total_lines} total lines (~${max_diff_c
         # Unwrap {{#IF_CLAUDE}}...{{/IF_CLAUDE}} blocks (remove tags, keep content)
         content="${content//\{\{#IF_CLAUDE\}\}/}"
         content="${content//\{\{\/IF_CLAUDE\}\}/}"
-    elif [[ "$_provider" == "codex" ]]; then
+    else
         # Remove {{#IF_CLAUDE}}...{{/IF_CLAUDE}} blocks (including tags and content)
         while [[ "$content" == *'{{#IF_CLAUDE}}'* ]]; do
             local before="${content%%\{\{#IF_CLAUDE\}\}*}"
@@ -949,6 +952,7 @@ PRINCIPLES
         implement)
             case "$complexity" in
                 solo) cat <<'REC_SOLO_IMPL'
+{{#IF_CLAUDE}}
 **Recommendation: Work solo.** Small scope — no team needed, but a rigorous security self-check is mandatory before creating the PR.
 - Lead implements, writes tests, commits, and creates PR.
 - Skip team creation and team shutdown steps in the workflow below.
@@ -958,23 +962,50 @@ PRINCIPLES
   - [ ] No sensitive data (PHI, PII, credentials) logged or included in error responses
   - [ ] Auth checks are present wherever data is accessed or modified
   - [ ] All callers of any modified function have been checked — including in unmodified files
+{{/IF_CLAUDE}}
+{{#IF_CODEX}}
+**Recommendation: Work solo with multi-perspective analysis.**
+Analyze from three perspectives before and after implementing:
+- **Engineering**: Implement code changes, ensure correctness and test coverage
+- **Security**: No hardcoded secrets, insecure storage, missing auth, OWASP vulnerabilities. Check all callers of modified functions — including in unmodified files
+- **Product**: Validate the implementation meets the issue's acceptance criteria
+{{/IF_CODEX}}
 
 REC_SOLO_IMPL
                     ;;
                 duo) cat <<'REC_DUO_IMPL'
+{{#IF_CLAUDE}}
 **Recommendation: Core team (3 agents).**
 - **builder** (`subagent_type: {{BUILDER_AGENT}}`): Implements code changes. Only teammate that writes code.
 - **security-reviewer** (`subagent_type: {{SECURITY_AGENT}}`): Reviews for hardcoded secrets, insecure storage, missing auth, OWASP vulnerabilities. Also checks all callers of modified functions in unmodified files.
 - **product-manager** (`subagent_type: {{PRODUCT_AGENT}}`): Validates the implementation meets the issue's acceptance criteria. Ensures nothing is over-engineered or under-scoped.
+{{/IF_CLAUDE}}
+{{#IF_CODEX}}
+**Recommendation: Work solo with multi-perspective analysis.**
+Analyze from three perspectives before and after implementing:
+- **Engineering**: Implement code changes, ensure correctness and test coverage
+- **Security**: Review for hardcoded secrets, insecure storage, missing auth, OWASP vulnerabilities. Check all callers of modified functions
+- **Product**: Validate the implementation meets the issue's acceptance criteria
+{{/IF_CODEX}}
 
 REC_DUO_IMPL
                     ;;
                 full|*) cat <<'REC_FULL_IMPL'
+{{#IF_CLAUDE}}
 **Recommendation: Full team (4 agents).**
 - **builder** (`subagent_type: {{BUILDER_AGENT}}`): Implements code changes. Only teammate that writes code.
 - **security-reviewer** (`subagent_type: {{SECURITY_AGENT}}`): Reviews for hardcoded secrets, insecure storage, missing auth, OWASP vulnerabilities.
 - **ux-reviewer** (`subagent_type: {{UX_AGENT}}`): Reviews UI/UX for usability, accessibility, friction. If no UI changes, focuses on API ergonomics.
 - **product-manager** (`subagent_type: {{PRODUCT_AGENT}}`): Validates implementation meets requirements. Ensures nothing is over-engineered or under-scoped.
+{{/IF_CLAUDE}}
+{{#IF_CODEX}}
+**Recommendation: Work solo with comprehensive multi-perspective analysis.**
+This is a large-scope task. Analyze thoroughly from four perspectives before and after implementing:
+- **Engineering**: Implement code changes, ensure correctness, test coverage, and architecture quality
+- **Security**: Review for hardcoded secrets, insecure storage, missing auth, OWASP vulnerabilities
+- **UX**: Review UI/UX for usability, accessibility, friction (if UI changes present)
+- **Product**: Validate implementation meets all requirements
+{{/IF_CODEX}}
 
 REC_FULL_IMPL
                     ;;
@@ -983,24 +1014,49 @@ REC_FULL_IMPL
         review)
             case "$complexity" in
                 solo) cat <<'REC_SOLO_REVIEW'
+{{#IF_CLAUDE}}
 **Recommendation: Minimum review team (2 agents).** Even small PRs require a security reviewer — do not review alone.
 - **platform-engineer** (`subagent_type: {{BUILDER_AGENT}}`): Reviews code quality, correctness, and tests. Checks all callers of modified functions, including in unmodified files.
 - **security-reviewer** (`subagent_type: {{SECURITY_AGENT}}`): Reviews for hardcoded secrets, insecure storage, missing auth, OWASP vulnerabilities.
+{{/IF_CLAUDE}}
+{{#IF_CODEX}}
+**Recommendation: Solo review with dual-perspective analysis.**
+Review from two perspectives:
+- **Code quality**: Review correctness, tests, architecture. Check all callers of modified functions
+- **Security**: Review for hardcoded secrets, insecure storage, missing auth, OWASP vulnerabilities
+{{/IF_CODEX}}
 
 REC_SOLO_REVIEW
                     ;;
                 duo) cat <<'REC_DUO_REVIEW'
+{{#IF_CLAUDE}}
 **Recommendation: Small review team (2 agents).**
 - **platform-engineer** (`subagent_type: {{BUILDER_AGENT}}`): Reviews code quality, architecture, patterns, performance, correctness. Must read surrounding source files — not just the diff. Must check all callers of modified functions across the entire codebase, including unmodified files.
 - **security-reviewer** (`subagent_type: {{SECURITY_AGENT}}`): Reviews for hardcoded secrets, insecure storage, missing auth, OWASP vulnerabilities.
+{{/IF_CLAUDE}}
+{{#IF_CODEX}}
+**Recommendation: Solo review with dual-perspective analysis.**
+Review from two perspectives:
+- **Code quality**: Review architecture, patterns, performance, correctness. Read surrounding source files — not just the diff. Check all callers of modified functions
+- **Security**: Review for hardcoded secrets, insecure storage, missing auth, OWASP vulnerabilities
+{{/IF_CODEX}}
 
 REC_DUO_REVIEW
                     ;;
                 full|*) cat <<'REC_FULL_REVIEW'
+{{#IF_CLAUDE}}
 **Recommendation: Full review team (3 agents). Platform-engineer is REQUIRED — do not go solo on full-complexity PRs.**
 - **platform-engineer** (`subagent_type: {{BUILDER_AGENT}}`): Reviews code quality, architecture, patterns, performance, correctness. Must read surrounding source files — not just the diff. Must check all callers of modified functions across the entire codebase, including unmodified files.
 - **security-reviewer** (`subagent_type: {{SECURITY_AGENT}}`): Reviews for hardcoded secrets, insecure storage, missing auth, OWASP vulnerabilities.
 - **ux-reviewer** (`subagent_type: {{UX_AGENT}}`): Reviews UI/UX changes for usability, accessibility, friction, consistency. Skip if no UI files in PR.
+{{/IF_CLAUDE}}
+{{#IF_CODEX}}
+**Recommendation: Solo review with comprehensive multi-perspective analysis.**
+This is a large-scope PR. Review thoroughly from three perspectives:
+- **Code quality**: Review architecture, patterns, performance, correctness. Read surrounding source files — not just the diff. Check all callers of modified functions
+- **Security**: Review for hardcoded secrets, insecure storage, missing auth, OWASP vulnerabilities
+- **UX**: Review UI/UX changes for usability, accessibility, friction, consistency (if UI files present)
+{{/IF_CODEX}}
 
 REC_FULL_REVIEW
                     ;;
@@ -1008,6 +1064,7 @@ REC_FULL_REVIEW
             ;;
         rework)
             cat <<'REC_REWORK'
+{{#IF_CLAUDE}}
 **Recommendation: Always spawn at minimum builder + security-reviewer.**
 A security reviewer is required after every rework — fixes to blocking issues can introduce new vulnerabilities, and a re-check after pushing is mandatory.
 
@@ -1019,13 +1076,22 @@ Read the review feedback, then decide on additional roles:
 - **Style/formatting nits only (no blocking issues)** → Builder works solo, but must run the mandatory security self-check before pushing.
 
 Announce your classification before spawning: "Feedback classification: [blocking-issues|security-concern|scope-question|style-only]. Team: [+security|+security+product|solo-with-checklist]."
+{{/IF_CLAUDE}}
+{{#IF_CODEX}}
+**Recommendation: Address all feedback solo with security self-check.**
+After addressing feedback, perform a mandatory security review of your own changes:
+- Verify all security-related feedback was correctly addressed
+- Check that fixes didn't introduce new vulnerabilities
+- Verify original acceptance criteria are still met
+{{/IF_CODEX}}
 
 REC_REWORK
             ;;
     esac
 
-    # --- Section D: Model Budget Guide ---
+    # --- Section D: Model Budget Guide (Claude-specific) ---
     cat <<'MODEL_GUIDE'
+{{#IF_CLAUDE}}
 ## Model Budget Guide
 
 | Agent Role | Default Model | When to Upgrade |
@@ -1038,11 +1104,13 @@ REC_REWORK
 Spawn each teammate using `model: "{{SUBAGENT_MODEL}}"` and `mode: "bypassPermissions"` in the Task tool call unless you have a specific reason to upgrade. The lead agent (you) already runs on the model specified by `CLAUDE_MODEL`.
 
 **CRITICAL**: You MUST pass `mode: "bypassPermissions"` on every Task tool call when spawning teammates. Without this, teammates will get stuck on "Waiting for team lead approval" for every Bash command and the entire job will stall.
+{{/IF_CLAUDE}}
 
 MODEL_GUIDE
 
-    # --- Section E: Available Roles ---
+    # --- Section E: Available Roles (Claude-specific) ---
     cat <<'ROLES'
+{{#IF_CLAUDE}}
 ## Available Roles
 
 All agent personas available for team composition:
@@ -1050,11 +1118,13 @@ All agent personas available for team composition:
 - `{{SECURITY_AGENT}}` — Security review
 - `{{PRODUCT_AGENT}}` — Product management / requirements validation
 - `{{UX_AGENT}}` — UX/accessibility review
+{{/IF_CLAUDE}}
 
 ROLES
 
     # --- Section F: Lead's Authority ---
     cat <<'AUTHORITY'
+{{#IF_CLAUDE}}
 ## Your Authority as Lead
 
 The complexity classification sets the **minimum** team — you may always add agents, never remove required ones. Your authority:
@@ -1062,6 +1132,15 @@ The complexity classification sets the **minimum** team — you may always add a
 - **Upgrade model assignments** — Upgrade subagents to opus for security-critical, auth-sensitive, or cryptographic code. The default is sonnet.
 - **Skip the UX reviewer only** — The UX reviewer may be skipped if there are genuinely no UI files in the PR (*.tsx, *.jsx, *.swift, *.kt, *.html, *.css, etc.). All other required roles must be spawned.
 - **Add agents** — If the task touches compliance-sensitive areas, add a compliance reviewer even if not recommended.
+{{/IF_CLAUDE}}
+{{#IF_CODEX}}
+## Quality Standards
+
+Even when working solo, maintain rigorous quality:
+- Always perform security self-review — never skip the security perspective
+- Check all callers of modified functions, including in unmodified files
+- If the task touches auth, crypto, or injection-sensitive code, be extra thorough in security analysis
+{{/IF_CODEX}}
 
 Ground your decisions in the Leadership Principles above. If you lack sufficient information to make a confident decision, add a comment asking for human guidance rather than guessing.
 AUTHORITY

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -722,7 +722,9 @@ $(cat "$footer_file")"
     fi
 
     # Determine provider (claude or codex)
-    local _provider="${PROVIDER:-claude}"
+    # AGENT_PROVIDER is canonical (set by lib/provider.sh + poll-github.sh routing)
+    # PROVIDER accepted as alias for backward compatibility
+    local _provider="${AGENT_PROVIDER:-${PROVIDER:-claude}}"
 
     # For Codex provider, use Codex model name instead of Claude's
     if [[ "$_provider" == "codex" ]]; then

--- a/lib/provider.sh
+++ b/lib/provider.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Zapat — Provider Abstraction Layer
+# Dispatches to the correct AI CLI provider based on AGENT_PROVIDER env var.
+# Source this file: source "$SCRIPT_DIR/lib/provider.sh"
+#
+# After sourcing, all provider_*() functions are available.
+# Default provider: claude (backward compatible).
+
+# Guard against double-sourcing
+[[ -n "${_ZAPAT_PROVIDER_LOADED:-}" ]] && return 0
+_ZAPAT_PROVIDER_LOADED=1
+
+# Resolve provider — default to claude for backward compatibility
+AGENT_PROVIDER="${AGENT_PROVIDER:-claude}"
+
+# Resolve path to provider implementations
+_PROVIDER_DIR="${_PROVIDER_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/providers" && pwd)}"
+
+# --- Credential Isolation ---
+# Only the active provider's credentials are exported. All other provider
+# credentials are unset to prevent accidental leakage across providers.
+_isolate_credentials() {
+    case "$AGENT_PROVIDER" in
+        claude)
+            # Keep Anthropic credentials, remove OpenAI
+            unset OPENAI_API_KEY 2>/dev/null || true
+            unset CODEX_MODEL 2>/dev/null || true
+            unset CODEX_SUBAGENT_MODEL 2>/dev/null || true
+            unset CODEX_UTILITY_MODEL 2>/dev/null || true
+            ;;
+        codex)
+            # Keep OpenAI credentials, remove Anthropic
+            unset ANTHROPIC_API_KEY 2>/dev/null || true
+            unset CLAUDE_MODEL 2>/dev/null || true
+            unset CLAUDE_SUBAGENT_MODEL 2>/dev/null || true
+            unset CLAUDE_UTILITY_MODEL 2>/dev/null || true
+            ;;
+        *)
+            # Unknown provider — don't touch credentials, let the provider handle it
+            ;;
+    esac
+}
+
+# --- Load Provider Implementation ---
+_provider_file="${_PROVIDER_DIR}/${AGENT_PROVIDER}.sh"
+
+if [[ ! -f "$_provider_file" ]]; then
+    echo "[ERROR] Unknown provider '${AGENT_PROVIDER}'. Available providers:" >&2
+    for f in "${_PROVIDER_DIR}"/*.sh; do
+        [[ -f "$f" ]] && echo "  - $(basename "$f" .sh)" >&2
+    done
+    return 1
+fi
+
+# shellcheck source=/dev/null
+source "$_provider_file"
+
+# Verify that the provider implements the required interface
+_required_functions=(
+    provider_run_noninteractive
+    provider_get_idle_pattern
+    provider_get_spinner_pattern
+    provider_get_rate_limit_pattern
+    provider_get_account_limit_pattern
+    provider_get_permission_pattern
+    provider_get_launch_cmd
+    provider_prereq_check
+    provider_get_model_shorthand
+)
+
+for fn in "${_required_functions[@]}"; do
+    if ! declare -f "$fn" &>/dev/null; then
+        echo "[ERROR] Provider '${AGENT_PROVIDER}' does not implement required function: $fn" >&2
+        return 1
+    fi
+done
+
+# Isolate credentials after loading provider
+_isolate_credentials

--- a/lib/provider.sh
+++ b/lib/provider.sh
@@ -42,6 +42,12 @@ _isolate_credentials() {
 }
 
 # --- Load Provider Implementation ---
+# Validate AGENT_PROVIDER to prevent path traversal (e.g., ../../etc/malicious)
+if [[ ! "$AGENT_PROVIDER" =~ ^[a-z0-9_-]+$ ]]; then
+    echo "[ERROR] Invalid AGENT_PROVIDER '${AGENT_PROVIDER}'. Must contain only lowercase letters, digits, hyphens, and underscores." >&2
+    return 1
+fi
+
 _provider_file="${_PROVIDER_DIR}/${AGENT_PROVIDER}.sh"
 
 if [[ ! -f "$_provider_file" ]]; then

--- a/lib/providers/claude.sh
+++ b/lib/providers/claude.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Zapat — Claude Code Provider
+# Implements the provider interface for Claude Code CLI.
+# This is the default provider and reproduces existing behavior exactly.
+
+# Run a non-interactive Claude Code session.
+# Usage: provider_run_noninteractive prompt_file model allowed_tools budget timeout
+# Returns: stdout = command output, exit code = 0 on success
+provider_run_noninteractive() {
+    local prompt_file="$1"
+    local model="${2:-${CLAUDE_MODEL:-claude-opus-4-6}}"
+    local allowed_tools="${3:-Read,Glob,Grep}"
+    local budget="${4:-5}"
+    local timeout="${5:-600}"
+
+    local timeout_cmd
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+        timeout_cmd="gtimeout"
+    else
+        timeout_cmd="timeout"
+    fi
+
+    $timeout_cmd "$timeout" claude \
+        -p "$(cat "$prompt_file")" \
+        --model "$model" \
+        --allowedTools "$allowed_tools" \
+        --max-budget-usd "$budget" \
+        2>&1
+}
+
+# Regex for idle detection in tmux pane (Claude at ❯ prompt with cost line)
+provider_get_idle_pattern() {
+    echo "^❯"
+}
+
+# Regex for active/working detection (spinner characters)
+provider_get_spinner_pattern() {
+    echo "(⠋|⠙|⠹|⠸|⠼|⠴|⠦|⠧|⠇|⠏|Working|Thinking)"
+}
+
+# Regex for rate limit detection
+provider_get_rate_limit_pattern() {
+    echo "(Switch to extra|Rate limit|rate_limit|429|Too Many Requests|Retry after)"
+}
+
+# Regex for account limit detection
+provider_get_account_limit_pattern() {
+    echo "(out of extra usage|resets [0-9]|usage limit|plan limit|You've reached)"
+}
+
+# Regex for permission prompts
+provider_get_permission_pattern() {
+    echo "(Allow once|Allow always|Do you want to allow|Do you want to (create|make|run|write|edit)|wants to use the .* tool|approve this action|Waiting for team lead approval)"
+}
+
+# Regex for fatal errors
+provider_get_fatal_pattern() {
+    echo "(FATAL|OOM|out of memory|Segmentation fault|core dumped|panic:|SIGKILL)"
+}
+
+# Full CLI invocation string for tmux session
+# Usage: provider_get_launch_cmd model
+provider_get_launch_cmd() {
+    local model="${1:-${CLAUDE_MODEL:-claude-opus-4-6}}"
+    echo "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 claude --model '${model}' --dangerously-skip-permissions --permission-mode bypassPermissions"
+}
+
+# Verify CLI is installed and auth is valid
+# Returns: 0 if ready, 1 if not
+provider_prereq_check() {
+    local failed=0
+    local failures=""
+
+    if ! command -v claude &>/dev/null; then
+        failures="${failures}\n- claude CLI not found (install: npm install -g @anthropic-ai/claude-code)"
+        failed=1
+    fi
+
+    if [[ $failed -ne 0 ]]; then
+        echo "$failures"
+        return 1
+    fi
+    return 0
+}
+
+# Convert full model name to shorthand for Task tool model parameter
+# Usage: provider_get_model_shorthand "claude-opus-4-6"
+# Returns: opus, sonnet, or haiku
+provider_get_model_shorthand() {
+    local model_string="${1:-}"
+    case "$model_string" in
+        *opus*)   echo "opus" ;;
+        *haiku*)  echo "haiku" ;;
+        *sonnet*) echo "sonnet" ;;
+        *)        echo "sonnet" ;;  # default fallback
+    esac
+}

--- a/lib/providers/codex.sh
+++ b/lib/providers/codex.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Zapat — OpenAI Codex Provider
+# Implements the provider interface for Codex CLI.
+
+# Run a non-interactive Codex session.
+# Usage: provider_run_noninteractive prompt_file model allowed_tools budget timeout
+# Returns: stdout = command output, exit code = 0 on success
+provider_run_noninteractive() {
+    local prompt_file="$1"
+    local model="${2:-${CODEX_MODEL:-codex}}"
+    local allowed_tools="${3:-}"
+    local budget="${4:-}"
+    local timeout="${5:-600}"
+
+    # Codex CLI does not support --allowedTools — log warning if specified
+    if [[ -n "$allowed_tools" ]]; then
+        echo "[WARN] Codex provider: --allowedTools not supported, ignoring: $allowed_tools" >&2
+    fi
+
+    # Codex CLI does not support --max-budget-usd — log warning if specified
+    if [[ -n "$budget" ]]; then
+        echo "[WARN] Codex provider: --max-budget-usd not supported, ignoring: \$${budget}" >&2
+    fi
+
+    local timeout_cmd
+    if [[ "$(uname -s)" == "Darwin" ]]; then
+        timeout_cmd="gtimeout"
+    else
+        timeout_cmd="timeout"
+    fi
+
+    # codex exec for non-interactive headless execution
+    $timeout_cmd "$timeout" codex exec \
+        --model "$model" \
+        --dangerously-bypass-approvals-and-sandbox \
+        "$(cat "$prompt_file")" \
+        2>&1
+}
+
+# Regex for idle detection in tmux pane
+provider_get_idle_pattern() {
+    echo "^>"
+}
+
+# Regex for active/working detection
+provider_get_spinner_pattern() {
+    echo "(Thinking|Working|Generating|\\.\\.\\.|⠋|⠙|⠹|⠸|⠼|⠴|⠦|⠧|⠇|⠏)"
+}
+
+# Regex for rate limit detection
+provider_get_rate_limit_pattern() {
+    echo "(Rate limit|rate_limit|429|Too Many Requests|Retry after)"
+}
+
+# Regex for account limit detection
+provider_get_account_limit_pattern() {
+    echo "(usage limit|quota exceeded|billing|insufficient_quota)"
+}
+
+# Regex for permission prompts
+provider_get_permission_pattern() {
+    echo "(Allow|Approve|Do you want to|approve this action)"
+}
+
+# Regex for fatal errors
+provider_get_fatal_pattern() {
+    echo "(FATAL|OOM|out of memory|Segmentation fault|core dumped|panic:|SIGKILL)"
+}
+
+# Full CLI invocation string for tmux session
+# Usage: provider_get_launch_cmd model
+provider_get_launch_cmd() {
+    local model="${1:-${CODEX_MODEL:-codex}}"
+    # Codex uses --dangerously-bypass-approvals-and-sandbox (maps to Claude's --dangerously-skip-permissions)
+    echo "codex --model '${model}' --dangerously-bypass-approvals-and-sandbox"
+}
+
+# Verify CLI is installed and auth is valid
+# Returns: 0 if ready, 1 if not
+provider_prereq_check() {
+    local failed=0
+    local failures=""
+
+    if ! command -v codex &>/dev/null; then
+        failures="${failures}\n- codex CLI not found (install: npm install -g @openai/codex)"
+        failed=1
+    fi
+
+    if [[ -z "${OPENAI_API_KEY:-}" ]]; then
+        failures="${failures}\n- OPENAI_API_KEY not set"
+        failed=1
+    fi
+
+    if [[ $failed -ne 0 ]]; then
+        echo "$failures"
+        return 1
+    fi
+    return 0
+}
+
+# Convert full model name to shorthand
+# Usage: provider_get_model_shorthand "o3"
+provider_get_model_shorthand() {
+    local model_string="${1:-}"
+    case "$model_string" in
+        *o3*)     echo "o3" ;;
+        *o4-mini*) echo "o4-mini" ;;
+        *codex*)  echo "codex" ;;
+        *)        echo "$model_string" ;;  # pass through unknown models
+    esac
+}

--- a/lib/tmux-helpers.sh
+++ b/lib/tmux-helpers.sh
@@ -10,6 +10,7 @@ TMUX_SESSION="${TMUX_SESSION:-zapat}"
 # to hardcoded Claude defaults for backward compatibility.
 _TMUX_HELPERS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if [[ -f "${_TMUX_HELPERS_DIR}/provider.sh" ]]; then
+    # shellcheck source=lib/provider.sh
     source "${_TMUX_HELPERS_DIR}/provider.sh"
     PANE_PATTERN_ACCOUNT_LIMIT="$(provider_get_account_limit_pattern)"
     PANE_PATTERN_RATE_LIMIT="$(provider_get_rate_limit_pattern)"

--- a/prompts/_shared-footer.txt
+++ b/prompts/_shared-footer.txt
@@ -8,4 +8,9 @@ Consult {{REPO_MAP}} below for the list of repositories and their types.
 {{COMPLIANCE_RULES}}
 
 ## Session Lifecycle
+{{#IF_CLAUDE}}
 When you have completed ALL steps in this task (including shutting down teammates if any), you MUST run `/exit` as your final action. Do not wait for further input — the pipeline monitors this session and will time it out if you idle. Running `/exit` ensures clean resource reclamation.
+{{/IF_CLAUDE}}
+{{#IF_CODEX}}
+When you have completed ALL steps in this task, simply end your response. Do not wait for further input — the pipeline monitors this session. No explicit exit command is needed.
+{{/IF_CODEX}}

--- a/prompts/implement-issue.txt
+++ b/prompts/implement-issue.txt
@@ -16,6 +16,7 @@
 
 ## Workflow
 
+{{#IF_CLAUDE}}
 If you are spawning a team, your **FIRST action** must be to call the `TeamCreate` tool, then use the `Task` tool to spawn each teammate. If working solo (only for `solo` complexity), skip team creation steps.
 
 1. **Phase 1 — Planning** (if team: all participate; if solo: plan yourself):
@@ -73,6 +74,48 @@ If you are spawning a team, your **FIRST action** must be to call the `TeamCreat
    ```
 
 6. **Shut down the team** when done (skip if working solo).
+{{/IF_CLAUDE}}
+{{#IF_CODEX}}
+You are working solo. Complete all phases sequentially.
+
+1. **Phase 1 — Planning**:
+   - Read relevant source files to understand existing patterns. Propose implementation plan.
+
+   **Interface Contract Check:** If the issue body contains an `## Interface Contract` section, you MUST implement exactly that interface — same method names, parameter types, return types, and delegate/callback signatures. Do NOT deviate from the contract.
+
+   **Backend API Spec Check:** If the issue body contains a `## Backend API Spec` section, you MUST use exactly that API — same HTTP method, URL, headers, and body format.
+
+2. **Phase 2 — Implementation**:
+   - Implement changes following existing code conventions
+   - Run any available tests/linters
+   - Commit with conventional commit messages (feat:/fix:/refactor:)
+
+3. **Phase 3 — Tests**:
+   - Write unit tests for all new/changed functions and classes
+   - Write integration tests if the change involves: API endpoints, database operations, or cross-service calls
+   - If the repo has no test infrastructure yet:
+     - Detect the stack (package.json → Jest/Vitest, .xcodeproj → XCTest)
+     - Install test devDependencies and create config as needed
+   - Run all tests — iterate until they pass
+   - Mock external dependencies — never make real API calls
+   - Commit tests with: `test: add tests for [description]`
+
+4. **Phase 4 — Self-Review**:
+   Perform a rigorous review from multiple perspectives:
+   - **Security**: No hardcoded secrets, no injection risks, auth checks present, all callers of modified functions verified
+   - **Code quality**: Follows existing patterns, no regressions, proper error handling
+   - **Product**: Meets all acceptance criteria from the issue
+
+5. **Phase 5 — Ship**:
+   Push and create PR:
+   ```
+   git push origin HEAD
+   gh pr create --title "feat: [description]" --body "..." --label "zapat-review"
+   ```
+   Link the issue in the PR body with "Closes #{{ISSUE_NUMBER}}".
+
+   **Target Branch:** If the issue body contains a `**Target Branch:** feature/SLUG` directive, the PR MUST target that branch instead of the default branch.
+{{/IF_CODEX}}
 
 ### Safety Notes
 - NEVER modify files outside the working directory

--- a/prompts/issue-triage.txt
+++ b/prompts/issue-triage.txt
@@ -78,15 +78,15 @@ Any blocking issues, prerequisites, or related work.
 Additional labels to add beyond what's already applied.
 
 ### Auto-Implementation Decision
-Based on the TEAM's collective analysis, decide if this issue should be automatically implemented by an agent team.
+Based on the analysis above, decide if this issue should be automatically implemented.
 
 **Add `agent-work` label** if ALL of these are true:
 - Acceptance criteria are clear enough for an engineer to implement
 - No external dependencies or API key provisioning needed (agent can't provision credentials)
 - No database schema migrations required (agent can't run migrations)
-- The team agrees the requirements are unambiguous
+- The requirements are unambiguous
 
-Complexity is NOT a blocker. Small, Medium, and Large issues should all be auto-implemented. The implementation team has 5 members (builder, security, UX, clinical, PM) and a human reviews the PR before merge. The worst outcome is a PR that needs rework.
+Complexity is NOT a blocker. Small, Medium, and Large issues should all be auto-implemented. The pipeline will assign an appropriately-sized team and a human reviews the PR before merge. The worst outcome is a PR that needs rework.
 
 **Do NOT add `agent-work`** only if:
 - Missing acceptance criteria (agent won't know what to build)

--- a/prompts/issue-triage.txt
+++ b/prompts/issue-triage.txt
@@ -1,6 +1,11 @@
+{{#IF_CLAUDE}}
 You are the engineering lead. You MUST create an Agent Team to triage this issue. Do NOT attempt to do this alone.
 
 **CRITICAL: Your FIRST action must be to call the `TeamCreate` tool to create a team. Then use the `Task` tool to spawn each teammate. Do NOT skip team creation. Do NOT do the triage yourself. The whole point is getting multiple expert perspectives.**
+{{/IF_CLAUDE}}
+{{#IF_CODEX}}
+You are the engineering lead. Analyze this issue thoroughly from multiple expert perspectives.
+{{/IF_CODEX}}
 
 ## Issue Details
 - **Repository**: {{REPO}}
@@ -17,6 +22,7 @@ You are the engineering lead. You MUST create an Agent Team to triage this issue
 
 ## Instructions
 
+{{#IF_CLAUDE}}
 1. **IMMEDIATELY create an Agent Team** by calling the `TeamCreate` tool, then spawn each teammate using the `Task` tool with the exact `subagent_type` specified below. These are focused expert personas (~1-2KB each) with specific domain expertise.
 
    - **engineer** — Use `subagent_type: {{BUILDER_AGENT}}` (select based on the repository type).
@@ -35,6 +41,18 @@ You are the engineering lead. You MUST create an Agent Team to triage this issue
    - All teammates send their analysis to you (the lead). You synthesize into the final triage.
 
 3. **Synthesize the final triage** from all teammate inputs. Use this format:
+{{/IF_CLAUDE}}
+{{#IF_CODEX}}
+Analyze this issue sequentially from each expert perspective:
+
+1. **Engineering perspective**: Read relevant source files to understand the current state. Assess which files are affected, estimate complexity (Small/Medium/Large), and suggest a technical approach.
+
+2. **Product perspective**: Assess priority (P0-P3), user impact, and whether this aligns with product goals. Consider trade-offs.
+
+3. **Security perspective**: Flag any security concerns with the proposed change. Does it touch auth or sensitive data flows?
+
+4. **Synthesize the final triage** combining all perspectives. Use this format:
+{{/IF_CODEX}}
 
 ## Issue Triage — #{{ISSUE_NUMBER}}: {{ISSUE_TITLE}}
 
@@ -92,13 +110,21 @@ If suitable, run:
 gh issue edit {{ISSUE_NUMBER}} --repo {{REPO}} --add-label "agent-research"
 ```
 
+{{#IF_CLAUDE}}
 4. **Post the triage as a GitHub comment** on the issue:
 ```
 gh issue comment {{ISSUE_NUMBER}} --repo {{REPO}} --body "YOUR_TRIAGE_OUTPUT"
 ```
 
 5. **Shut down the team** when done.
+{{/IF_CLAUDE}}
+{{#IF_CODEX}}
+5. **Post the triage as a GitHub comment** on the issue:
+```
+gh issue comment {{ISSUE_NUMBER}} --repo {{REPO}} --body "YOUR_TRIAGE_OUTPUT"
+```
+{{/IF_CODEX}}
 
 ### Safety Notes
-- All teammates are read-only — no code changes, only analysis
+- All analysis is read-only — no code changes, only analysis
 - Keep the triage concise and actionable

--- a/prompts/issue-triage.txt
+++ b/prompts/issue-triage.txt
@@ -60,7 +60,7 @@ Analyze this issue sequentially from each expert perspective:
 Small (< 1 day), Medium (1-3 days), or Large (3+ days) — with brief justification from the engineer's analysis.
 
 ### Suggested Priority
-P0-critical, P1-high, P2-medium, or P3-low — incorporating the product manager's rationale and clinical advisor's perspective.
+P0-critical, P1-high, P2-medium, or P3-low — incorporating the product manager's rationale.
 
 ### Security Considerations
 Any security implications — from the security reviewer. "None" if clean.

--- a/prompts/pr-review.txt
+++ b/prompts/pr-review.txt
@@ -23,6 +23,7 @@
 
 ## Workflow
 
+{{#IF_CLAUDE}}
 Your **FIRST action** must be to call the `TeamCreate` tool, then use the `Task` tool to spawn each teammate. Always spawn a team — do not review alone.
 
 1. **Team Setup**:
@@ -35,6 +36,21 @@ Your **FIRST action** must be to call the `TeamCreate` tool, then use the `Task`
    - **security-reviewer**: Check for hardcoded secrets/API keys, sensitive data in insecure storage, missing auth checks, injection risks.
    - **UX reviewer** (if spawned): Evaluate for friction, accessibility, responsive design, and consistency.
    - All teammates send their review to you (the lead). You synthesize into the final review.
+{{/IF_CLAUDE}}
+{{#IF_CODEX}}
+You are reviewing this PR solo. Analyze it from multiple expert perspectives.
+
+1. **Code Quality Review**:
+   - Read surrounding source files — not just the diff. For every function **modified** by this PR, find all callers across the entire codebase (including unmodified files) and verify they correctly handle the new behavior.
+   - Check for crash risks, unhandled rejections, error handling gaps, and performance concerns.
+
+2. **Security Review**:
+   - Check for hardcoded secrets/API keys, sensitive data in insecure storage, missing auth checks, injection risks.
+
+3. **UX Review** (if applicable):
+   - If the PR contains UI-related files (*.tsx, *.jsx, *.vue, *.svelte, *.css, *.scss, *.html, *.swift, *.kt), evaluate for friction, accessibility, responsive design, and consistency.
+   - If no UI files are present, note "No UI changes — UX review skipped."
+{{/IF_CODEX}}
 
 3. **Review guidelines — DO NOT flag**:
    - Swift/TypeScript style that matches existing code patterns
@@ -85,8 +101,10 @@ List each suggestion with a clear, actionable description. Prefix each with `- [
 gh pr comment {{PR_NUMBER}} --repo {{REPO}} --body "YOUR_REVIEW_OUTPUT"
 ```
 
+{{#IF_CLAUDE}}
 6. **Shut down the team** when done.
+{{/IF_CLAUDE}}
 
 ### Safety Notes
-- All teammates are read-only — no code changes, only review
+- All review is read-only — no code changes, only review
 - Review the CHANGES, not the entire codebase. Don't flag existing patterns.

--- a/prompts/research-issue.txt
+++ b/prompts/research-issue.txt
@@ -1,6 +1,11 @@
+{{#IF_CLAUDE}}
 You are the engineering lead. You MUST create an Agent Team to research and analyze this issue. Do NOT attempt to do this alone.
 
 **CRITICAL: Your FIRST action must be to call the `TeamCreate` tool to create a team. Then use the `Task` tool to spawn each teammate. Do NOT skip team creation. Do NOT do the research yourself. The whole point is getting multiple expert perspectives.**
+{{/IF_CLAUDE}}
+{{#IF_CODEX}}
+You are the engineering lead. Research and analyze this issue thoroughly from multiple expert perspectives.
+{{/IF_CODEX}}
 
 ## Issue Details
 - **Repository**: {{REPO}}
@@ -15,6 +20,7 @@ You are the engineering lead. You MUST create an Agent Team to research and anal
 
 ## Instructions
 
+{{#IF_CLAUDE}}
 1. **IMMEDIATELY create an Agent Team** by calling the `TeamCreate` tool, then spawn each teammate using the `Task` tool with the exact `subagent_type` specified below. Select teammates based on what the issue requires:
 
    **Always include:**
@@ -37,6 +43,18 @@ You are the engineering lead. You MUST create an Agent Team to research and anal
    - Team reaches consensus on recommendations
 
 3. **Produce a structured research output** with these sections:
+{{/IF_CLAUDE}}
+{{#IF_CODEX}}
+Analyze this issue sequentially from each expert perspective:
+
+1. **Product perspective**: Feature prioritization, roadmap alignment, cross-team trade-offs. Analyze which recommendations are most impactful and how they fit the product strategy.
+
+2. **Engineering perspective**: Read relevant source code and documentation. Assess technical feasibility, architecture considerations, and implementation approach.
+
+3. **Security perspective** (if applicable): Evaluate security implications if the issue touches auth, data flows, or sensitive systems.
+
+4. **Produce a structured research output** with these sections:
+{{/IF_CODEX}}
 
 ## Research Report — #{{ISSUE_NUMBER}}: {{ISSUE_TITLE}}
 
@@ -131,9 +149,11 @@ For each actionable recommendation, specify:
    ```
    If the original issue represents an ongoing concern that should remain open, add the research comment but do NOT close it.
 
+{{#IF_CLAUDE}}
 7. **Shut down the team** when done.
+{{/IF_CLAUDE}}
 
 ### Safety Notes
-- All teammates are read-only — no code changes, only analysis and issue creation
+- All analysis is read-only — no code changes, only analysis and issue creation
 - Keep the research report concise and actionable
 - Do NOT create `agent-research` sub-issues unless the research question is genuinely separate from this one

--- a/prompts/rework-pr.txt
+++ b/prompts/rework-pr.txt
@@ -20,6 +20,7 @@
 
 ## Workflow
 
+{{#IF_CLAUDE}}
 If you are spawning a team, your **FIRST action** must be to call the `TeamCreate` tool, then use the `Task` tool to spawn each teammate. Only skip team creation if the feedback is confirmed style-nits-only with no blocking issues.
 
 1. **Analyze Feedback**:
@@ -46,6 +47,27 @@ If you are spawning a team, your **FIRST action** must be to call the `TeamCreat
    - All send their assessment to you (the lead).
 
 6. **Shut down the team** when done (skip if working solo).
+{{/IF_CLAUDE}}
+{{#IF_CODEX}}
+You are working solo. Address all review feedback sequentially.
+
+1. **Analyze Feedback**:
+   Read all review feedback carefully. Classify each piece using the Feedback Triage Guide below.
+
+2. **Phase 1 — Blocking Issues (must fix):**
+   - Address ALL blocking issues first — things marked as "blocking", "must fix", "required", or that point out bugs, security issues, or correctness problems.
+   - Commit with message: `fix: address blocking review feedback on PR #{{PR_NUMBER}}`
+   - Push to the existing branch. Do NOT force-push or rebase — add commits on top.
+
+3. **Phase 2 — Suggestions & Improvements (should fix):**
+   - Address ALL remaining feedback — suggestions, improvements, refactoring ideas, naming changes, documentation additions, test suggestions, and "nice to have" items.
+   - Treat suggestions as actionable work, not optional. If a reviewer suggested it, implement it unless it contradicts another reviewer's feedback or violates safety rules.
+   - Commit SEPARATELY from blocking fixes with message: `refactor: implement review suggestions on PR #{{PR_NUMBER}}`
+
+4. **Phase 3 — Self-Review:**
+   - Verify all security-related feedback was correctly addressed and no new issues were introduced.
+   - Verify the original acceptance criteria are still met and no regressions were introduced.
+{{/IF_CODEX}}
 
 ## Feedback Triage Guide
 

--- a/tests/test-tmux-helpers.bats
+++ b/tests/test-tmux-helpers.bats
@@ -185,24 +185,49 @@ teardown() {
 # --- Permission pattern tests ---
 # Load actual patterns from tmux-helpers.sh for testing
 
+# Load patterns from provider abstraction (claude provider is default)
 _load_permission_pattern() {
-    local src="${BATS_TEST_DIRNAME}/../lib/tmux-helpers.sh"
-    PANE_PATTERN_PERMISSION=$(grep '^PANE_PATTERN_PERMISSION=' "$src" | sed 's/^PANE_PATTERN_PERMISSION=//' | tr -d '"')
+    local provider_dir="${BATS_TEST_DIRNAME}/../lib/providers"
+    if [[ -f "$provider_dir/claude.sh" ]]; then
+        source "$provider_dir/claude.sh"
+        PANE_PATTERN_PERMISSION="$(provider_get_permission_pattern)"
+    else
+        local src="${BATS_TEST_DIRNAME}/../lib/tmux-helpers.sh"
+        PANE_PATTERN_PERMISSION=$(grep 'PANE_PATTERN_PERMISSION=' "$src" | head -1 | sed 's/.*PANE_PATTERN_PERMISSION=//' | tr -d '"')
+    fi
 }
 
 _load_rate_limit_pattern() {
-    local src="${BATS_TEST_DIRNAME}/../lib/tmux-helpers.sh"
-    PANE_PATTERN_RATE_LIMIT=$(grep '^PANE_PATTERN_RATE_LIMIT=' "$src" | sed 's/^PANE_PATTERN_RATE_LIMIT=//' | tr -d '"')
+    local provider_dir="${BATS_TEST_DIRNAME}/../lib/providers"
+    if [[ -f "$provider_dir/claude.sh" ]]; then
+        source "$provider_dir/claude.sh"
+        PANE_PATTERN_RATE_LIMIT="$(provider_get_rate_limit_pattern)"
+    else
+        local src="${BATS_TEST_DIRNAME}/../lib/tmux-helpers.sh"
+        PANE_PATTERN_RATE_LIMIT=$(grep 'PANE_PATTERN_RATE_LIMIT=' "$src" | head -1 | sed 's/.*PANE_PATTERN_RATE_LIMIT=//' | tr -d '"')
+    fi
 }
 
 _load_account_limit_pattern() {
-    local src="${BATS_TEST_DIRNAME}/../lib/tmux-helpers.sh"
-    PANE_PATTERN_ACCOUNT_LIMIT=$(grep '^PANE_PATTERN_ACCOUNT_LIMIT=' "$src" | sed 's/^PANE_PATTERN_ACCOUNT_LIMIT=//' | tr -d '"')
+    local provider_dir="${BATS_TEST_DIRNAME}/../lib/providers"
+    if [[ -f "$provider_dir/claude.sh" ]]; then
+        source "$provider_dir/claude.sh"
+        PANE_PATTERN_ACCOUNT_LIMIT="$(provider_get_account_limit_pattern)"
+    else
+        local src="${BATS_TEST_DIRNAME}/../lib/tmux-helpers.sh"
+        PANE_PATTERN_ACCOUNT_LIMIT=$(grep 'PANE_PATTERN_ACCOUNT_LIMIT=' "$src" | head -1 | sed 's/.*PANE_PATTERN_ACCOUNT_LIMIT=//' | tr -d '"')
+    fi
 }
 
 _load_fatal_pattern() {
-    local src="${BATS_TEST_DIRNAME}/../lib/tmux-helpers.sh"
-    PANE_PATTERN_FATAL=$(grep '^PANE_PATTERN_FATAL=' "$src" | sed 's/^PANE_PATTERN_FATAL=//' | tr -d '"')
+    local provider_dir="${BATS_TEST_DIRNAME}/../lib/providers"
+    if [[ -f "$provider_dir/claude.sh" ]]; then
+        source "$provider_dir/claude.sh"
+        PANE_PATTERN_FATAL="$(provider_get_fatal_pattern)"
+    else
+        local src="${BATS_TEST_DIRNAME}/../lib/tmux-helpers.sh"
+        PANE_PATTERN_FATAL=$(grep 'PANE_PATTERN_FATAL=' "$src" | head -1 | sed 's/.*PANE_PATTERN_FATAL=//' | tr -d '"')
+    fi
 }
 
 # -- Motivation: the OLD broad pattern caused false positives --

--- a/tests/test_integration.bats
+++ b/tests/test_integration.bats
@@ -1,0 +1,271 @@
+#!/usr/bin/env bats
+
+# Integration tests for the Zapat pipeline
+# Tests end-to-end flows through the state machine, auto-merge gate,
+# risk classifier, and sequential flow enforcement.
+
+load '../node_modules/bats-support/load'
+load '../node_modules/bats-assert/load'
+
+REPO_ROOT="$BATS_TEST_DIRNAME/.."
+
+setup() {
+    export AUTOMATION_DIR="$BATS_TEST_TMPDIR/zapat"
+    mkdir -p "$AUTOMATION_DIR/state/items"
+    mkdir -p "$AUTOMATION_DIR/logs"
+    export ITEM_STATE_DIR="$AUTOMATION_DIR/state/items"
+
+    source "$REPO_ROOT/lib/common.sh"
+    source "$REPO_ROOT/lib/item-state.sh"
+}
+
+teardown() {
+    rm -rf "$BATS_TEST_TMPDIR/zapat"
+}
+
+# --- State Machine Transitions ---
+
+@test "integration: pending -> running -> completed lifecycle" {
+    run create_item_state "owner/repo" "issue" "1" "pending" "default"
+    assert_success
+    local state_file="$output"
+
+    run jq -r '.status' "$state_file"
+    assert_output "pending"
+
+    run update_item_state "$state_file" "running"
+    assert_success
+
+    run jq -r '.status' "$state_file"
+    assert_output "running"
+
+    run update_item_state "$state_file" "completed"
+    assert_success
+
+    run jq -r '.status' "$state_file"
+    assert_output "completed"
+}
+
+@test "integration: pending -> running -> failed -> running (retry)" {
+    run create_item_state "owner/repo" "pr" "10" "pending" "default"
+    assert_success
+    local state_file="$output"
+
+    run update_item_state "$state_file" "running"
+    assert_success
+
+    run update_item_state "$state_file" "failed"
+    assert_success
+
+    run jq -r '.status' "$state_file"
+    assert_output "failed"
+
+    # After retry timer elapses, should_process_item allows reprocessing
+    # Simulate by clearing next_retry_after
+    jq '.next_retry_after = 0' "$state_file" > "${state_file}.tmp" && mv "${state_file}.tmp" "$state_file"
+
+    run should_process_item "owner/repo" "pr" "10" "default"
+    assert_success
+}
+
+@test "integration: completed items are skipped" {
+    run create_item_state "owner/repo" "issue" "5" "pending" "default"
+    assert_success
+    local state_file="$output"
+
+    run update_item_state "$state_file" "completed"
+    assert_success
+
+    run should_process_item "owner/repo" "issue" "5" "default"
+    assert_failure
+}
+
+@test "integration: abandoned items are skipped" {
+    run create_item_state "owner/repo" "work" "7" "pending" "default"
+    assert_success
+    local state_file="$output"
+
+    run update_item_state "$state_file" "abandoned"
+    assert_success
+
+    run should_process_item "owner/repo" "work" "7" "default"
+    assert_failure
+}
+
+# --- Cycle Counter Enforcement ---
+
+@test "integration: rework cycle counter increments correctly" {
+    run create_item_state "owner/repo" "rework" "20" "pending" "default"
+    assert_success
+
+    run get_rework_cycles "owner/repo" "rework" "20" "default"
+    assert_output "0"
+
+    run increment_rework_cycles "owner/repo" "rework" "20" "default"
+    assert_success
+
+    run get_rework_cycles "owner/repo" "rework" "20" "default"
+    assert_output "1"
+
+    run increment_rework_cycles "owner/repo" "rework" "20" "default"
+    assert_success
+
+    run get_rework_cycles "owner/repo" "rework" "20" "default"
+    assert_output "2"
+}
+
+@test "integration: cycle counter survives state transitions" {
+    run create_item_state "owner/repo" "rework" "30" "pending" "default"
+    assert_success
+    local state_file="$output"
+
+    run increment_rework_cycles "owner/repo" "rework" "30" "default"
+    assert_success
+
+    run update_item_state "$state_file" "running"
+    assert_success
+
+    run update_item_state "$state_file" "completed"
+    assert_success
+
+    # Cycle count preserved after state changes
+    run get_rework_cycles "owner/repo" "rework" "30" "default"
+    assert_output "1"
+}
+
+# --- Sequential Flow Enforcement ---
+
+@test "integration: on-rework-pr.sh adds zapat-testing not zapat-review" {
+    run grep -c 'add-label.*zapat-testing' "$REPO_ROOT/triggers/on-rework-pr.sh"
+    assert_success
+
+    # Must NOT add zapat-review directly (breaks sequential flow)
+    run grep 'add-label.*zapat-review' "$REPO_ROOT/triggers/on-rework-pr.sh"
+    assert_failure
+}
+
+@test "integration: on-test-pr.sh routes to review on pass, rework on fail" {
+    run grep 'zapat-review' "$REPO_ROOT/triggers/on-test-pr.sh"
+    assert_success
+
+    run grep 'zapat-rework' "$REPO_ROOT/triggers/on-test-pr.sh"
+    assert_success
+}
+
+@test "integration: on-work-issue.sh adds only zapat-testing after PR" {
+    run grep 'add-label.*zapat-testing' "$REPO_ROOT/triggers/on-work-issue.sh"
+    assert_success
+
+    # Should not add zapat-review directly (sequential: testing first)
+    run grep 'add-label.*zapat-review' "$REPO_ROOT/triggers/on-work-issue.sh"
+    assert_failure
+}
+
+# --- Auto-Merge Gate Branch Check ---
+
+@test "integration: auto-merge gate queries baseRefName" {
+    run grep 'baseRefName' "$REPO_ROOT/bin/poll-github.sh"
+    assert_success
+}
+
+@test "integration: auto-merge gate skips non-main PRs" {
+    run grep -A 5 'MERGE_PR_BASE' "$REPO_ROOT/bin/poll-github.sh"
+    assert_success
+    assert_output --partial 'not main'
+}
+
+# --- Risk Classifier Pipeline-Critical Patterns ---
+
+@test "integration: risk classifier has pipeline-critical patterns" {
+    run grep 'PIPELINE_CRITICAL_PATTERNS' "$REPO_ROOT/src/commands/risk.mjs"
+    assert_success
+}
+
+@test "integration: risk classifier checks pipeline-critical before other patterns" {
+    # PIPELINE_CRITICAL_PATTERNS must be checked first in classifyFile
+    run grep -A 3 'function classifyFile' "$REPO_ROOT/src/commands/risk.mjs"
+    assert_success
+    assert_output --partial 'PIPELINE_CRITICAL_PATTERNS'
+}
+
+@test "integration: risk classifier flags lib/item-state.sh as pipeline-critical" {
+    run grep 'item-state' "$REPO_ROOT/src/commands/risk.mjs"
+    assert_success
+}
+
+@test "integration: risk classifier flags bin/poll-github.sh as pipeline-critical" {
+    run grep 'poll-github' "$REPO_ROOT/src/commands/risk.mjs"
+    assert_success
+}
+
+@test "integration: risk classifier flags triggers as pipeline-critical" {
+    run grep 'triggers' "$REPO_ROOT/src/commands/risk.mjs"
+    assert_success
+}
+
+# --- Post-Merge Health Check ---
+
+@test "integration: post-merge health check exists in auto-merge gate" {
+    run grep 'post-merge-health' "$REPO_ROOT/bin/poll-github.sh"
+    assert_success
+}
+
+@test "integration: health check runs after low-risk auto-merge" {
+    # Verify the health check is placed after gh pr merge for low risk
+    local low_risk_section
+    low_risk_section=$(sed -n '/Auto-merging low-risk/,/;;/p' "$REPO_ROOT/bin/poll-github.sh")
+    echo "$low_risk_section" | grep -q 'zapat.*health'
+}
+
+@test "integration: health check runs after medium-risk auto-merge" {
+    local medium_risk_section
+    medium_risk_section=$(sed -n '/Auto-merging medium-risk/,/;;/p' "$REPO_ROOT/bin/poll-github.sh")
+    echo "$medium_risk_section" | grep -q 'zapat.*health'
+}
+
+# --- Feature Branch Workflow Documentation ---
+
+@test "integration: CLAUDE.md documents multi-PR feature branch workflow" {
+    run grep -i 'Multi-PR Feature Branches' "$REPO_ROOT/CLAUDE.md"
+    assert_success
+}
+
+@test "integration: CLAUDE.md mentions hold label for sub-PRs" {
+    run grep 'hold.*label' "$REPO_ROOT/CLAUDE.md"
+    assert_success
+}
+
+# --- Provider Integration ---
+
+@test "integration: detect_provider_label is called before each dispatch" {
+    # Every dispatch section should call detect_provider_label
+    local dispatch_sections
+    dispatch_sections=$(grep -c 'detect_provider_label' "$REPO_ROOT/bin/poll-github.sh")
+    # At minimum: PRs, review PRs, issues, work issues, rework PRs, testing PRs,
+    # write-tests issues, research issues, mentions (PR+issue), auto-triage, retry sweep
+    [ "$dispatch_sections" -ge 10 ]
+}
+
+@test "integration: provider.sh validates AGENT_PROVIDER against path traversal" {
+    run grep 'path traversal\|[^a-z0-9_-]' "$REPO_ROOT/lib/provider.sh"
+    assert_success
+}
+
+# --- Dedup Files ---
+
+@test "integration: all dedup files are created in state dir" {
+    local dedup_files
+    dedup_files=$(grep -c 'PROCESSED_.*=.*processed-' "$REPO_ROOT/bin/poll-github.sh")
+    # Should have: prs, issues, work, rework, write-tests, research, testing, mentions, auto-triage, auto-rework, rebase
+    [ "$dedup_files" -ge 11 ]
+}
+
+@test "integration: processed-testing.txt exists in dedup file list" {
+    run grep 'processed-testing' "$REPO_ROOT/bin/poll-github.sh"
+    assert_success
+}
+
+@test "integration: processed-auto-rework.txt exists in dedup file list" {
+    run grep 'processed-auto-rework' "$REPO_ROOT/bin/poll-github.sh"
+    assert_success
+}

--- a/tests/test_provider.bats
+++ b/tests/test_provider.bats
@@ -269,6 +269,39 @@ EOF
     echo "429 error" | grep -qE "$pattern"
 }
 
+# --- Path traversal prevention tests ---
+
+@test "provider.sh rejects AGENT_PROVIDER with path traversal" {
+    export AGENT_PROVIDER="../../etc/malicious"
+    export _PROVIDER_DIR="$TEST_DIR/lib/providers"
+    run source "$TEST_DIR/lib/provider.sh"
+    assert_failure
+    assert_output --partial "Invalid AGENT_PROVIDER"
+}
+
+@test "provider.sh rejects AGENT_PROVIDER with slashes" {
+    export AGENT_PROVIDER="foo/bar"
+    export _PROVIDER_DIR="$TEST_DIR/lib/providers"
+    run source "$TEST_DIR/lib/provider.sh"
+    assert_failure
+    assert_output --partial "Invalid AGENT_PROVIDER"
+}
+
+@test "provider.sh rejects AGENT_PROVIDER with dots" {
+    export AGENT_PROVIDER="claude.sh"
+    export _PROVIDER_DIR="$TEST_DIR/lib/providers"
+    run source "$TEST_DIR/lib/provider.sh"
+    assert_failure
+    assert_output --partial "Invalid AGENT_PROVIDER"
+}
+
+@test "provider.sh accepts valid AGENT_PROVIDER names" {
+    export AGENT_PROVIDER=claude
+    export _PROVIDER_DIR="$TEST_DIR/lib/providers"
+    source "$TEST_DIR/lib/provider.sh"
+    assert_equal "$AGENT_PROVIDER" "claude"
+}
+
 # --- Double-source guard test ---
 
 @test "provider.sh can be sourced twice without error" {

--- a/tests/test_provider.bats
+++ b/tests/test_provider.bats
@@ -1,0 +1,301 @@
+#!/usr/bin/env bats
+# Tests for lib/provider.sh: provider dispatch, credential isolation, interface compliance
+
+load '../node_modules/bats-support/load'
+load '../node_modules/bats-assert/load'
+
+setup() {
+    export TEST_DIR="$(mktemp -d)"
+    export AUTOMATION_DIR="$TEST_DIR"
+    mkdir -p "$TEST_DIR/lib/providers"
+    mkdir -p "$TEST_DIR/logs"
+
+    # Copy real provider files
+    cp "$BATS_TEST_DIRNAME/../lib/provider.sh" "$TEST_DIR/lib/provider.sh"
+    cp "$BATS_TEST_DIRNAME/../lib/providers/claude.sh" "$TEST_DIR/lib/providers/claude.sh"
+    cp "$BATS_TEST_DIRNAME/../lib/providers/codex.sh" "$TEST_DIR/lib/providers/codex.sh"
+
+    # Reset provider loaded guard between tests
+    unset _ZAPAT_PROVIDER_LOADED
+}
+
+teardown() {
+    rm -rf "$TEST_DIR"
+    unset _ZAPAT_PROVIDER_LOADED
+    unset AGENT_PROVIDER
+    unset OPENAI_API_KEY
+    unset ANTHROPIC_API_KEY
+    unset CLAUDE_MODEL
+    unset CODEX_MODEL
+    unset CLAUDE_SUBAGENT_MODEL
+    unset CODEX_SUBAGENT_MODEL
+    unset CLAUDE_UTILITY_MODEL
+    unset CODEX_UTILITY_MODEL
+}
+
+# --- Provider dispatch tests ---
+
+@test "provider.sh defaults to claude when AGENT_PROVIDER is unset" {
+    unset AGENT_PROVIDER
+    export _PROVIDER_DIR="$TEST_DIR/lib/providers"
+    source "$TEST_DIR/lib/provider.sh"
+    assert_equal "$AGENT_PROVIDER" "claude"
+}
+
+@test "provider.sh loads claude provider when AGENT_PROVIDER=claude" {
+    export AGENT_PROVIDER=claude
+    export _PROVIDER_DIR="$TEST_DIR/lib/providers"
+    source "$TEST_DIR/lib/provider.sh"
+    # Verify claude-specific function behavior
+    run provider_get_idle_pattern
+    assert_output "^❯"
+}
+
+@test "provider.sh loads codex provider when AGENT_PROVIDER=codex" {
+    export AGENT_PROVIDER=codex
+    export _PROVIDER_DIR="$TEST_DIR/lib/providers"
+    source "$TEST_DIR/lib/provider.sh"
+    # Verify codex-specific function behavior
+    run provider_get_idle_pattern
+    assert_output "^>"
+}
+
+@test "provider.sh fails for unknown provider" {
+    export AGENT_PROVIDER=unknown
+    export _PROVIDER_DIR="$TEST_DIR/lib/providers"
+    run source "$TEST_DIR/lib/provider.sh"
+    assert_failure
+    assert_output --partial "Unknown provider 'unknown'"
+}
+
+@test "provider.sh fails when provider is missing required function" {
+    export AGENT_PROVIDER=broken
+    export _PROVIDER_DIR="$TEST_DIR/lib/providers"
+    # Create a broken provider that's missing functions
+    cat > "$TEST_DIR/lib/providers/broken.sh" <<'EOF'
+provider_run_noninteractive() { echo "ok"; }
+# Missing all other required functions
+EOF
+    run source "$TEST_DIR/lib/provider.sh"
+    assert_failure
+    assert_output --partial "does not implement required function"
+}
+
+# --- Credential isolation tests ---
+
+@test "claude provider unsets OPENAI_API_KEY" {
+    export AGENT_PROVIDER=claude
+    export OPENAI_API_KEY="sk-test-key"
+    export _PROVIDER_DIR="$TEST_DIR/lib/providers"
+    source "$TEST_DIR/lib/provider.sh"
+    assert_equal "${OPENAI_API_KEY:-}" ""
+}
+
+@test "claude provider unsets CODEX_MODEL" {
+    export AGENT_PROVIDER=claude
+    export CODEX_MODEL="codex"
+    export _PROVIDER_DIR="$TEST_DIR/lib/providers"
+    source "$TEST_DIR/lib/provider.sh"
+    assert_equal "${CODEX_MODEL:-}" ""
+}
+
+@test "claude provider unsets CODEX_SUBAGENT_MODEL" {
+    export AGENT_PROVIDER=claude
+    export CODEX_SUBAGENT_MODEL="codex"
+    export _PROVIDER_DIR="$TEST_DIR/lib/providers"
+    source "$TEST_DIR/lib/provider.sh"
+    assert_equal "${CODEX_SUBAGENT_MODEL:-}" ""
+}
+
+@test "claude provider unsets CODEX_UTILITY_MODEL" {
+    export AGENT_PROVIDER=claude
+    export CODEX_UTILITY_MODEL="codex"
+    export _PROVIDER_DIR="$TEST_DIR/lib/providers"
+    source "$TEST_DIR/lib/provider.sh"
+    assert_equal "${CODEX_UTILITY_MODEL:-}" ""
+}
+
+@test "codex provider unsets ANTHROPIC_API_KEY" {
+    export AGENT_PROVIDER=codex
+    export ANTHROPIC_API_KEY="sk-ant-test-key"
+    export _PROVIDER_DIR="$TEST_DIR/lib/providers"
+    source "$TEST_DIR/lib/provider.sh"
+    assert_equal "${ANTHROPIC_API_KEY:-}" ""
+}
+
+@test "codex provider unsets CLAUDE_MODEL" {
+    export AGENT_PROVIDER=codex
+    export CLAUDE_MODEL="claude-opus-4-6"
+    export _PROVIDER_DIR="$TEST_DIR/lib/providers"
+    source "$TEST_DIR/lib/provider.sh"
+    assert_equal "${CLAUDE_MODEL:-}" ""
+}
+
+@test "codex provider unsets CLAUDE_SUBAGENT_MODEL" {
+    export AGENT_PROVIDER=codex
+    export CLAUDE_SUBAGENT_MODEL="claude-sonnet-4-6"
+    export _PROVIDER_DIR="$TEST_DIR/lib/providers"
+    source "$TEST_DIR/lib/provider.sh"
+    assert_equal "${CLAUDE_SUBAGENT_MODEL:-}" ""
+}
+
+@test "codex provider unsets CLAUDE_UTILITY_MODEL" {
+    export AGENT_PROVIDER=codex
+    export CLAUDE_UTILITY_MODEL="claude-haiku-4-5-20251001"
+    export _PROVIDER_DIR="$TEST_DIR/lib/providers"
+    source "$TEST_DIR/lib/provider.sh"
+    assert_equal "${CLAUDE_UTILITY_MODEL:-}" ""
+}
+
+# --- Claude provider interface tests ---
+
+@test "claude: provider_get_rate_limit_pattern matches expected strings" {
+    export AGENT_PROVIDER=claude
+    export _PROVIDER_DIR="$TEST_DIR/lib/providers"
+    source "$TEST_DIR/lib/provider.sh"
+    local pattern
+    pattern=$(provider_get_rate_limit_pattern)
+    echo "Switch to extra" | grep -qE "$pattern"
+    echo "Rate limit exceeded" | grep -qE "$pattern"
+    echo "429 error" | grep -qE "$pattern"
+}
+
+@test "claude: provider_get_account_limit_pattern matches expected strings" {
+    export AGENT_PROVIDER=claude
+    export _PROVIDER_DIR="$TEST_DIR/lib/providers"
+    source "$TEST_DIR/lib/provider.sh"
+    local pattern
+    pattern=$(provider_get_account_limit_pattern)
+    echo "out of extra usage" | grep -qE "$pattern"
+    echo "plan limit" | grep -qE "$pattern"
+}
+
+@test "claude: provider_get_permission_pattern matches Claude CLI prompts" {
+    export AGENT_PROVIDER=claude
+    export _PROVIDER_DIR="$TEST_DIR/lib/providers"
+    source "$TEST_DIR/lib/provider.sh"
+    local pattern
+    pattern=$(provider_get_permission_pattern)
+    echo "Allow once" | grep -qE "$pattern"
+    echo "Allow always" | grep -qE "$pattern"
+    echo "wants to use the Bash tool" | grep -qE "$pattern"
+}
+
+@test "claude: provider_get_permission_pattern does NOT match bypass permissions" {
+    export AGENT_PROVIDER=claude
+    export _PROVIDER_DIR="$TEST_DIR/lib/providers"
+    source "$TEST_DIR/lib/provider.sh"
+    local pattern
+    pattern=$(provider_get_permission_pattern)
+    ! echo "bypass permissions on" | grep -qE "$pattern"
+}
+
+@test "claude: provider_get_launch_cmd includes model and bypass flags" {
+    export AGENT_PROVIDER=claude
+    export _PROVIDER_DIR="$TEST_DIR/lib/providers"
+    source "$TEST_DIR/lib/provider.sh"
+    run provider_get_launch_cmd "claude-sonnet-4-6"
+    assert_output --partial "claude"
+    assert_output --partial "claude-sonnet-4-6"
+    assert_output --partial "--dangerously-skip-permissions"
+}
+
+@test "claude: provider_prereq_check succeeds when claude is installed" {
+    export AGENT_PROVIDER=claude
+    export _PROVIDER_DIR="$TEST_DIR/lib/providers"
+    source "$TEST_DIR/lib/provider.sh"
+    # claude should be available in the test environment
+    if command -v claude &>/dev/null; then
+        run provider_prereq_check
+        assert_success
+    else
+        skip "claude CLI not installed in test environment"
+    fi
+}
+
+@test "claude: provider_get_model_shorthand maps model names correctly" {
+    export AGENT_PROVIDER=claude
+    export _PROVIDER_DIR="$TEST_DIR/lib/providers"
+    source "$TEST_DIR/lib/provider.sh"
+
+    run provider_get_model_shorthand "claude-opus-4-6"
+    assert_output "opus"
+
+    run provider_get_model_shorthand "claude-sonnet-4-6"
+    assert_output "sonnet"
+
+    run provider_get_model_shorthand "claude-haiku-4-5-20251001"
+    assert_output "haiku"
+
+    # Unknown model defaults to sonnet
+    run provider_get_model_shorthand "unknown-model"
+    assert_output "sonnet"
+}
+
+# --- Codex provider interface tests ---
+
+@test "codex: provider_get_launch_cmd includes dangerously-bypass flag" {
+    export AGENT_PROVIDER=codex
+    export _PROVIDER_DIR="$TEST_DIR/lib/providers"
+    source "$TEST_DIR/lib/provider.sh"
+    run provider_get_launch_cmd "o3"
+    assert_output --partial "codex"
+    assert_output --partial "o3"
+    assert_output --partial "--dangerously-bypass-approvals-and-sandbox"
+}
+
+@test "codex: provider_get_model_shorthand maps OpenAI models" {
+    export AGENT_PROVIDER=codex
+    export _PROVIDER_DIR="$TEST_DIR/lib/providers"
+    source "$TEST_DIR/lib/provider.sh"
+
+    run provider_get_model_shorthand "o3"
+    assert_output "o3"
+
+    run provider_get_model_shorthand "o4-mini"
+    assert_output "o4-mini"
+
+    run provider_get_model_shorthand "codex"
+    assert_output "codex"
+}
+
+@test "codex: provider_get_rate_limit_pattern matches expected strings" {
+    export AGENT_PROVIDER=codex
+    export _PROVIDER_DIR="$TEST_DIR/lib/providers"
+    source "$TEST_DIR/lib/provider.sh"
+    local pattern
+    pattern=$(provider_get_rate_limit_pattern)
+    echo "Rate limit exceeded" | grep -qE "$pattern"
+    echo "429 error" | grep -qE "$pattern"
+}
+
+# --- Double-source guard test ---
+
+@test "provider.sh can be sourced twice without error" {
+    export AGENT_PROVIDER=claude
+    export _PROVIDER_DIR="$TEST_DIR/lib/providers"
+    source "$TEST_DIR/lib/provider.sh"
+    # Second source should be a no-op (guard prevents re-loading)
+    source "$TEST_DIR/lib/provider.sh"
+    # Functions should still work
+    run provider_get_idle_pattern
+    assert_output "^❯"
+}
+
+# --- tmux-helpers backward compatibility ---
+
+@test "launch_claude_session alias exists and delegates to launch_agent_session" {
+    # Source tmux-helpers.sh in a subshell with stubbed dependencies
+    (
+        export AGENT_PROVIDER=claude
+        export _PROVIDER_DIR="$TEST_DIR/lib/providers"
+        # Stub log functions
+        log_info() { :; }
+        log_warn() { :; }
+        log_error() { :; }
+        _log_structured() { :; }
+        source "$BATS_TEST_DIRNAME/../lib/tmux-helpers.sh"
+        # Verify the alias function exists
+        declare -f launch_claude_session &>/dev/null
+    )
+}

--- a/tests/test_provider_conditional.bats
+++ b/tests/test_provider_conditional.bats
@@ -1,0 +1,539 @@
+#!/usr/bin/env bats
+
+# Tests for provider-conditional block processing in substitute_prompt()
+# Issue #52: Codex-compatible prompt templates
+
+load '../node_modules/bats-support/load'
+load '../node_modules/bats-assert/load'
+
+setup() {
+    export AUTOMATION_DIR="$BATS_TEST_TMPDIR/zapat"
+    mkdir -p "$AUTOMATION_DIR/state"
+    mkdir -p "$AUTOMATION_DIR/logs"
+    mkdir -p "$AUTOMATION_DIR/config"
+    mkdir -p "$BATS_TEST_TMPDIR/prompts"
+
+    # Create minimal repos.conf so read_repos doesn't fail
+    touch "$AUTOMATION_DIR/config/repos.conf"
+
+    source "$BATS_TEST_DIRNAME/../lib/common.sh"
+}
+
+teardown() {
+    rm -rf "$BATS_TEST_TMPDIR/zapat"
+    rm -rf "$BATS_TEST_TMPDIR/prompts"
+    unset AGENT_PROVIDER
+}
+
+# --- Default provider detection ---
+
+@test "default provider is claude when AGENT_PROVIDER is unset" {
+    unset AGENT_PROVIDER
+    cat > "$BATS_TEST_TMPDIR/prompts/test.txt" <<'EOF'
+Provider: {{PROVIDER}}
+EOF
+
+    run substitute_prompt "$BATS_TEST_TMPDIR/prompts/test.txt"
+    assert_success
+    assert_output --partial "Provider: claude"
+}
+
+@test "AGENT_PROVIDER=codex sets provider to codex" {
+    export AGENT_PROVIDER=codex
+    cat > "$BATS_TEST_TMPDIR/prompts/test.txt" <<'EOF'
+Provider: {{PROVIDER}}
+EOF
+
+    run substitute_prompt "$BATS_TEST_TMPDIR/prompts/test.txt"
+    assert_success
+    assert_output --partial "Provider: codex"
+}
+
+# --- IF_CLAUDE block processing ---
+
+@test "IF_CLAUDE blocks are kept when provider is claude" {
+    unset AGENT_PROVIDER
+    cat > "$BATS_TEST_TMPDIR/prompts/test.txt" <<'EOF'
+Before
+{{#IF_CLAUDE}}
+Claude content here
+{{/IF_CLAUDE}}
+After
+EOF
+
+    run substitute_prompt "$BATS_TEST_TMPDIR/prompts/test.txt"
+    assert_success
+    assert_output --partial "Claude content here"
+    assert_output --partial "Before"
+    assert_output --partial "After"
+}
+
+@test "IF_CLAUDE blocks are removed when provider is codex" {
+    export AGENT_PROVIDER=codex
+    cat > "$BATS_TEST_TMPDIR/prompts/test.txt" <<'EOF'
+Before
+{{#IF_CLAUDE}}
+Claude content here
+{{/IF_CLAUDE}}
+After
+EOF
+
+    run substitute_prompt "$BATS_TEST_TMPDIR/prompts/test.txt"
+    assert_success
+    refute_output --partial "Claude content here"
+    assert_output --partial "Before"
+    assert_output --partial "After"
+}
+
+# --- IF_CODEX block processing ---
+
+@test "IF_CODEX blocks are removed when provider is claude" {
+    unset AGENT_PROVIDER
+    cat > "$BATS_TEST_TMPDIR/prompts/test.txt" <<'EOF'
+Before
+{{#IF_CODEX}}
+Codex content here
+{{/IF_CODEX}}
+After
+EOF
+
+    run substitute_prompt "$BATS_TEST_TMPDIR/prompts/test.txt"
+    assert_success
+    refute_output --partial "Codex content here"
+    assert_output --partial "Before"
+    assert_output --partial "After"
+}
+
+@test "IF_CODEX blocks are kept when provider is codex" {
+    export AGENT_PROVIDER=codex
+    cat > "$BATS_TEST_TMPDIR/prompts/test.txt" <<'EOF'
+Before
+{{#IF_CODEX}}
+Codex content here
+{{/IF_CODEX}}
+After
+EOF
+
+    run substitute_prompt "$BATS_TEST_TMPDIR/prompts/test.txt"
+    assert_success
+    assert_output --partial "Codex content here"
+    assert_output --partial "Before"
+    assert_output --partial "After"
+}
+
+# --- Tag stripping ---
+
+@test "IF_CLAUDE tags are stripped from active content (no leftover tags)" {
+    unset AGENT_PROVIDER
+    cat > "$BATS_TEST_TMPDIR/prompts/test.txt" <<'EOF'
+{{#IF_CLAUDE}}
+Active content
+{{/IF_CLAUDE}}
+EOF
+
+    run substitute_prompt "$BATS_TEST_TMPDIR/prompts/test.txt"
+    assert_success
+    assert_output --partial "Active content"
+    refute_output --partial "{{#IF_CLAUDE}}"
+    refute_output --partial "{{/IF_CLAUDE}}"
+}
+
+@test "IF_CODEX tags are stripped from active content (no leftover tags)" {
+    export AGENT_PROVIDER=codex
+    cat > "$BATS_TEST_TMPDIR/prompts/test.txt" <<'EOF'
+{{#IF_CODEX}}
+Active content
+{{/IF_CODEX}}
+EOF
+
+    run substitute_prompt "$BATS_TEST_TMPDIR/prompts/test.txt"
+    assert_success
+    assert_output --partial "Active content"
+    refute_output --partial "{{#IF_CODEX}}"
+    refute_output --partial "{{/IF_CODEX}}"
+}
+
+# --- Mixed conditional blocks ---
+
+@test "mixed IF_CLAUDE and IF_CODEX blocks resolve correctly for claude" {
+    unset AGENT_PROVIDER
+    cat > "$BATS_TEST_TMPDIR/prompts/test.txt" <<'EOF'
+Header
+{{#IF_CLAUDE}}
+Use TeamCreate tool
+{{/IF_CLAUDE}}
+{{#IF_CODEX}}
+Work solo
+{{/IF_CODEX}}
+Footer
+EOF
+
+    run substitute_prompt "$BATS_TEST_TMPDIR/prompts/test.txt"
+    assert_success
+    assert_output --partial "Use TeamCreate tool"
+    refute_output --partial "Work solo"
+    assert_output --partial "Header"
+    assert_output --partial "Footer"
+}
+
+@test "mixed IF_CLAUDE and IF_CODEX blocks resolve correctly for codex" {
+    export AGENT_PROVIDER=codex
+    cat > "$BATS_TEST_TMPDIR/prompts/test.txt" <<'EOF'
+Header
+{{#IF_CLAUDE}}
+Use TeamCreate tool
+{{/IF_CLAUDE}}
+{{#IF_CODEX}}
+Work solo
+{{/IF_CODEX}}
+Footer
+EOF
+
+    run substitute_prompt "$BATS_TEST_TMPDIR/prompts/test.txt"
+    assert_success
+    refute_output --partial "Use TeamCreate tool"
+    assert_output --partial "Work solo"
+    assert_output --partial "Header"
+    assert_output --partial "Footer"
+}
+
+# --- Multiple blocks of same type ---
+
+@test "multiple IF_CLAUDE blocks are all processed correctly" {
+    unset AGENT_PROVIDER
+    cat > "$BATS_TEST_TMPDIR/prompts/test.txt" <<'EOF'
+Start
+{{#IF_CLAUDE}}
+Block 1
+{{/IF_CLAUDE}}
+Middle
+{{#IF_CLAUDE}}
+Block 2
+{{/IF_CLAUDE}}
+End
+EOF
+
+    run substitute_prompt "$BATS_TEST_TMPDIR/prompts/test.txt"
+    assert_success
+    assert_output --partial "Block 1"
+    assert_output --partial "Block 2"
+    assert_output --partial "Middle"
+}
+
+# --- PROVIDER placeholder ---
+
+@test "PROVIDER placeholder resolves to claude by default" {
+    unset AGENT_PROVIDER
+    cat > "$BATS_TEST_TMPDIR/prompts/test.txt" <<'EOF'
+Running on {{PROVIDER}} provider
+EOF
+
+    run substitute_prompt "$BATS_TEST_TMPDIR/prompts/test.txt"
+    assert_success
+    assert_output --partial "Running on claude provider"
+}
+
+@test "PROVIDER placeholder resolves to codex when set" {
+    export AGENT_PROVIDER=codex
+    cat > "$BATS_TEST_TMPDIR/prompts/test.txt" <<'EOF'
+Running on {{PROVIDER}} provider
+EOF
+
+    run substitute_prompt "$BATS_TEST_TMPDIR/prompts/test.txt"
+    assert_success
+    assert_output --partial "Running on codex provider"
+}
+
+# --- Input sanitization ---
+
+@test "AGENT_PROVIDER with path traversal characters is sanitized" {
+    export AGENT_PROVIDER="../../../etc/passwd"
+    cat > "$BATS_TEST_TMPDIR/prompts/test.txt" <<'EOF'
+Provider: {{PROVIDER}}
+EOF
+
+    run substitute_prompt "$BATS_TEST_TMPDIR/prompts/test.txt"
+    assert_success
+    # Path traversal chars are stripped, leaving "etcpasswd"
+    refute_output --partial "../"
+    refute_output --partial "/"
+}
+
+@test "AGENT_PROVIDER with empty value defaults to claude" {
+    export AGENT_PROVIDER=""
+    cat > "$BATS_TEST_TMPDIR/prompts/test.txt" <<'EOF'
+Provider: {{PROVIDER}}
+EOF
+
+    run substitute_prompt "$BATS_TEST_TMPDIR/prompts/test.txt"
+    assert_success
+    assert_output --partial "Provider: claude"
+}
+
+@test "AGENT_PROVIDER with special characters is sanitized to safe value" {
+    export AGENT_PROVIDER='$(evil_cmd)'
+    cat > "$BATS_TEST_TMPDIR/prompts/test.txt" <<'EOF'
+Provider: {{PROVIDER}}
+EOF
+
+    run substitute_prompt "$BATS_TEST_TMPDIR/prompts/test.txt"
+    assert_success
+    # Injection characters ($, parens) are stripped; safe chars (letters, underscore) remain
+    refute_output --partial '$(evil_cmd)'
+    assert_output --partial "Provider: evil_cmd"
+}
+
+# --- Conditional blocks in footer ---
+
+@test "conditional blocks in shared footer are processed correctly" {
+    cat > "$BATS_TEST_TMPDIR/prompts/test.txt" <<'EOF'
+Main content
+EOF
+    cat > "$BATS_TEST_TMPDIR/prompts/_shared-footer.txt" <<'EOF'
+{{#IF_CLAUDE}}
+Run /exit when done
+{{/IF_CLAUDE}}
+{{#IF_CODEX}}
+Simply end your response
+{{/IF_CODEX}}
+EOF
+
+    unset AGENT_PROVIDER
+    run substitute_prompt "$BATS_TEST_TMPDIR/prompts/test.txt"
+    assert_success
+    assert_output --partial "Run /exit when done"
+    refute_output --partial "Simply end your response"
+}
+
+@test "conditional blocks in footer work for codex provider" {
+    cat > "$BATS_TEST_TMPDIR/prompts/test.txt" <<'EOF'
+Main content
+EOF
+    cat > "$BATS_TEST_TMPDIR/prompts/_shared-footer.txt" <<'EOF'
+{{#IF_CLAUDE}}
+Run /exit when done
+{{/IF_CLAUDE}}
+{{#IF_CODEX}}
+Simply end your response
+{{/IF_CODEX}}
+EOF
+
+    export AGENT_PROVIDER=codex
+    run substitute_prompt "$BATS_TEST_TMPDIR/prompts/test.txt"
+    assert_success
+    refute_output --partial "Run /exit when done"
+    assert_output --partial "Simply end your response"
+}
+
+# --- Conditional blocks inside TASK_ASSESSMENT (two-pass) ---
+
+@test "conditional blocks inside TASK_ASSESSMENT are processed correctly" {
+    cat > "$BATS_TEST_TMPDIR/prompts/test.txt" <<'EOF'
+{{TASK_ASSESSMENT}}
+EOF
+
+    local assessment='{{#IF_CLAUDE}}
+Spawn team with TeamCreate
+{{/IF_CLAUDE}}
+{{#IF_CODEX}}
+Work solo
+{{/IF_CODEX}}'
+
+    unset AGENT_PROVIDER
+    run substitute_prompt "$BATS_TEST_TMPDIR/prompts/test.txt" "TASK_ASSESSMENT=$assessment"
+    assert_success
+    assert_output --partial "Spawn team with TeamCreate"
+    refute_output --partial "Work solo"
+}
+
+@test "conditional blocks inside TASK_ASSESSMENT work for codex" {
+    cat > "$BATS_TEST_TMPDIR/prompts/test.txt" <<'EOF'
+{{TASK_ASSESSMENT}}
+EOF
+
+    local assessment='{{#IF_CLAUDE}}
+Spawn team with TeamCreate
+{{/IF_CLAUDE}}
+{{#IF_CODEX}}
+Work solo
+{{/IF_CODEX}}'
+
+    export AGENT_PROVIDER=codex
+    run substitute_prompt "$BATS_TEST_TMPDIR/prompts/test.txt" "TASK_ASSESSMENT=$assessment"
+    assert_success
+    refute_output --partial "Spawn team with TeamCreate"
+    assert_output --partial "Work solo"
+}
+
+# --- No regression on real prompt templates ---
+
+@test "real implement-issue.txt produces valid output for claude provider" {
+    unset AGENT_PROVIDER
+    local real_prompts="$BATS_TEST_DIRNAME/../prompts"
+    run substitute_prompt "$real_prompts/implement-issue.txt" \
+        "REPO=test/repo" "ISSUE_NUMBER=1" "ISSUE_TITLE=Test" \
+        "ISSUE_LABELS=agent-work" "COMPLEXITY=duo" "ISSUE_BODY=Test body" \
+        "MENTION_CONTEXT=" "TASK_ASSESSMENT=Test assessment"
+    assert_success
+    # Claude content should be present
+    assert_output --partial "TeamCreate"
+    # Codex content should be absent
+    refute_output --partial "working solo. Complete all phases"
+}
+
+@test "real implement-issue.txt produces valid output for codex provider" {
+    export AGENT_PROVIDER=codex
+    local real_prompts="$BATS_TEST_DIRNAME/../prompts"
+    run substitute_prompt "$real_prompts/implement-issue.txt" \
+        "REPO=test/repo" "ISSUE_NUMBER=1" "ISSUE_TITLE=Test" \
+        "ISSUE_LABELS=agent-work" "COMPLEXITY=duo" "ISSUE_BODY=Test body" \
+        "MENTION_CONTEXT=" "TASK_ASSESSMENT=Test assessment"
+    assert_success
+    # Codex content should be present
+    assert_output --partial "solo"
+    # Claude-specific content should be absent
+    refute_output --partial "TeamCreate"
+    refute_output --partial "Task tool"
+}
+
+# --- Codex prompts must not contain Claude-specific references ---
+
+@test "codex issue-triage.txt has no Claude-specific references" {
+    export AGENT_PROVIDER=codex
+    local real_prompts="$BATS_TEST_DIRNAME/../prompts"
+    run substitute_prompt "$real_prompts/issue-triage.txt" \
+        "REPO=test/repo" "ISSUE_NUMBER=1" "ISSUE_TITLE=Test" \
+        "ISSUE_LABELS=agent" "ISSUE_BODY=Test body" "MENTION_CONTEXT="
+    assert_success
+    refute_output --partial "TeamCreate"
+    refute_output --partial "Task tool"
+    refute_output --partial "/exit"
+}
+
+@test "codex pr-review.txt has no Claude-specific references" {
+    export AGENT_PROVIDER=codex
+    local real_prompts="$BATS_TEST_DIRNAME/../prompts"
+    run substitute_prompt "$real_prompts/pr-review.txt" \
+        "REPO=test/repo" "PR_NUMBER=1" "PR_TITLE=Test PR" \
+        "PR_BODY=Test body" "PR_FILES=src/main.ts" "PR_DIFF=+new" \
+        "COMPLEXITY=duo" "MENTION_CONTEXT=" \
+        "TASK_ASSESSMENT=Test assessment"
+    assert_success
+    refute_output --partial "TeamCreate"
+    refute_output --partial "Task tool"
+    refute_output --partial "/exit"
+}
+
+@test "codex research-issue.txt has no Claude-specific references" {
+    export AGENT_PROVIDER=codex
+    local real_prompts="$BATS_TEST_DIRNAME/../prompts"
+    run substitute_prompt "$real_prompts/research-issue.txt" \
+        "REPO=test/repo" "ISSUE_NUMBER=1" "ISSUE_TITLE=Test" \
+        "ISSUE_LABELS=agent-research" "ISSUE_BODY=Test body"
+    assert_success
+    refute_output --partial "TeamCreate"
+    refute_output --partial "Task tool"
+    refute_output --partial "/exit"
+}
+
+@test "codex rework-pr.txt has no Claude-specific references" {
+    export AGENT_PROVIDER=codex
+    local real_prompts="$BATS_TEST_DIRNAME/../prompts"
+    run substitute_prompt "$real_prompts/rework-pr.txt" \
+        "REPO=test/repo" "PR_NUMBER=1" "PR_TITLE=Test PR" \
+        "PR_BODY=Test body" "PR_BRANCH=agent/test" \
+        "COMPLEXITY=duo" "REVIEW_COMMENTS=Looks good" \
+        "PR_REVIEWS=Approved" \
+        "TASK_ASSESSMENT=Test assessment"
+    assert_success
+    refute_output --partial "TeamCreate"
+    refute_output --partial "Task tool"
+    refute_output --partial "/exit"
+}
+
+# --- generate_task_assessment with provider conditionals ---
+
+@test "generate_task_assessment duo/implement contains IF_CLAUDE blocks" {
+    run generate_task_assessment "duo" "implement"
+    assert_success
+    assert_output --partial "{{#IF_CLAUDE}}"
+    assert_output --partial "{{/IF_CLAUDE}}"
+    assert_output --partial "{{#IF_CODEX}}"
+    assert_output --partial "{{/IF_CODEX}}"
+}
+
+@test "generate_task_assessment solo/implement contains security checklist" {
+    run generate_task_assessment "solo" "implement"
+    assert_success
+    assert_output --partial "security checklist"
+}
+
+@test "generate_task_assessment full/review contains IF_CLAUDE blocks" {
+    run generate_task_assessment "full" "review"
+    assert_success
+    assert_output --partial "{{#IF_CLAUDE}}"
+    assert_output --partial "{{#IF_CODEX}}"
+}
+
+@test "generate_task_assessment rework contains IF_CLAUDE blocks" {
+    run generate_task_assessment "duo" "rework"
+    assert_success
+    assert_output --partial "{{#IF_CLAUDE}}"
+    assert_output --partial "{{#IF_CODEX}}"
+}
+
+# --- End-to-end: assessment + prompt substitution ---
+
+@test "full pipeline: assessment + prompt for claude resolves all conditionals" {
+    unset AGENT_PROVIDER
+    local assessment
+    assessment=$(generate_task_assessment "duo" "implement")
+
+    cat > "$BATS_TEST_TMPDIR/prompts/test.txt" <<'EOF'
+{{TASK_ASSESSMENT}}
+---
+Issue: {{ISSUE_NUMBER}}
+EOF
+
+    run substitute_prompt "$BATS_TEST_TMPDIR/prompts/test.txt" \
+        "TASK_ASSESSMENT=$assessment" "ISSUE_NUMBER=42"
+    assert_success
+    # Claude team instructions should be present
+    assert_output --partial "Core team (3 agents)"
+    # Codex solo instructions should be absent
+    refute_output --partial "Work solo with multi-perspective"
+    # No leftover conditional tags
+    refute_output --partial "{{#IF_CLAUDE}}"
+    refute_output --partial "{{/IF_CLAUDE}}"
+    refute_output --partial "{{#IF_CODEX}}"
+    refute_output --partial "{{/IF_CODEX}}"
+    # Issue number resolved
+    assert_output --partial "Issue: 42"
+}
+
+@test "full pipeline: assessment + prompt for codex resolves all conditionals" {
+    export AGENT_PROVIDER=codex
+    local assessment
+    assessment=$(generate_task_assessment "duo" "implement")
+
+    cat > "$BATS_TEST_TMPDIR/prompts/test.txt" <<'EOF'
+{{TASK_ASSESSMENT}}
+---
+Issue: {{ISSUE_NUMBER}}
+EOF
+
+    run substitute_prompt "$BATS_TEST_TMPDIR/prompts/test.txt" \
+        "TASK_ASSESSMENT=$assessment" "ISSUE_NUMBER=42"
+    assert_success
+    # Codex solo instructions should be present
+    assert_output --partial "Work solo with multi-perspective"
+    # Claude team instructions should be absent
+    refute_output --partial "Core team (3 agents)"
+    # No leftover conditional tags
+    refute_output --partial "{{#IF_CLAUDE}}"
+    refute_output --partial "{{/IF_CLAUDE}}"
+    refute_output --partial "{{#IF_CODEX}}"
+    refute_output --partial "{{/IF_CODEX}}"
+    # Issue number resolved
+    assert_output --partial "Issue: 42"
+}

--- a/tests/test_provider_conditionals.bats
+++ b/tests/test_provider_conditionals.bats
@@ -30,6 +30,7 @@ EOF
 
 teardown() {
     unset PROVIDER
+    unset AGENT_PROVIDER
     unset CODEX_MODEL
     rm -rf "$BATS_TEST_TMPDIR/zapat"
     rm -rf "$BATS_TEST_TMPDIR/prompts"
@@ -343,4 +344,25 @@ EOF
     assert_output --partial "Line 2"
     assert_output --partial "Line 3"
     refute_output --partial "Codex line 1"
+}
+
+# --- AGENT_PROVIDER env var (canonical, set by lib/provider.sh) ---
+
+@test "AGENT_PROVIDER=codex activates Codex blocks" {
+    export AGENT_PROVIDER=codex
+    printf '{{#IF_CLAUDE}}claude{{/IF_CLAUDE}}{{#IF_CODEX}}codex{{/IF_CODEX}}' > "$TEMPLATE"
+    run substitute_prompt "$TEMPLATE"
+    assert_success
+    assert_output --partial "codex"
+    refute_output --partial "claude"
+}
+
+@test "AGENT_PROVIDER takes precedence over PROVIDER" {
+    export AGENT_PROVIDER=codex
+    export PROVIDER=claude
+    printf '{{#IF_CLAUDE}}claude{{/IF_CLAUDE}}{{#IF_CODEX}}codex{{/IF_CODEX}}' > "$TEMPLATE"
+    run substitute_prompt "$TEMPLATE"
+    assert_success
+    assert_output --partial "codex"
+    refute_output --partial "claude"
 }

--- a/tests/test_provider_conditionals.bats
+++ b/tests/test_provider_conditionals.bats
@@ -1,0 +1,346 @@
+#!/usr/bin/env bats
+
+# Tests for provider-conditional block processing in substitute_prompt() (issue #52)
+
+load '../node_modules/bats-support/load'
+load '../node_modules/bats-assert/load'
+
+setup() {
+    export AUTOMATION_DIR="$BATS_TEST_TMPDIR/zapat"
+    mkdir -p "$AUTOMATION_DIR/state"
+    mkdir -p "$AUTOMATION_DIR/logs"
+    mkdir -p "$AUTOMATION_DIR/config"
+    mkdir -p "$BATS_TEST_TMPDIR/prompts"
+
+    # Create minimal repos.conf so read_repos doesn't fail
+    touch "$AUTOMATION_DIR/config/repos.conf"
+
+    # Create minimal agents.conf
+    cat > "$AUTOMATION_DIR/config/agents.conf" <<'EOF'
+builder=engineer
+security=security-reviewer
+product=product-manager
+ux=ux-reviewer
+EOF
+
+    source "$BATS_TEST_DIRNAME/../lib/common.sh"
+
+    TEMPLATE="$BATS_TEST_TMPDIR/prompts/template.txt"
+}
+
+teardown() {
+    unset PROVIDER
+    unset CODEX_MODEL
+    rm -rf "$BATS_TEST_TMPDIR/zapat"
+    rm -rf "$BATS_TEST_TMPDIR/prompts"
+}
+
+# --- Default provider behavior ---
+
+@test "default provider is claude when PROVIDER is unset" {
+    unset PROVIDER
+    printf '{{#IF_CLAUDE}}claude-content{{/IF_CLAUDE}}{{#IF_CODEX}}codex-content{{/IF_CODEX}}' > "$TEMPLATE"
+    run substitute_prompt "$TEMPLATE"
+    assert_success
+    assert_output --partial "claude-content"
+    refute_output --partial "codex-content"
+}
+
+@test "PROVIDER=claude keeps Claude blocks and strips Codex blocks" {
+    export PROVIDER=claude
+    printf '{{#IF_CLAUDE}}claude-content{{/IF_CLAUDE}}{{#IF_CODEX}}codex-content{{/IF_CODEX}}' > "$TEMPLATE"
+    run substitute_prompt "$TEMPLATE"
+    assert_success
+    assert_output --partial "claude-content"
+    refute_output --partial "codex-content"
+}
+
+@test "PROVIDER=codex keeps Codex blocks and strips Claude blocks" {
+    export PROVIDER=codex
+    printf '{{#IF_CLAUDE}}claude-content{{/IF_CLAUDE}}{{#IF_CODEX}}codex-content{{/IF_CODEX}}' > "$TEMPLATE"
+    run substitute_prompt "$TEMPLATE"
+    assert_success
+    assert_output --partial "codex-content"
+    refute_output --partial "claude-content"
+}
+
+# --- Subagent model selection ---
+
+@test "Codex provider uses o3 as default subagent model" {
+    export PROVIDER=codex
+    unset CODEX_MODEL
+    printf 'Model: {{SUBAGENT_MODEL}}' > "$TEMPLATE"
+    run substitute_prompt "$TEMPLATE"
+    assert_success
+    assert_output --partial "Model: o3"
+}
+
+@test "Codex provider respects CODEX_MODEL override" {
+    export PROVIDER=codex
+    export CODEX_MODEL=gpt-4o
+    printf 'Model: {{SUBAGENT_MODEL}}' > "$TEMPLATE"
+    run substitute_prompt "$TEMPLATE"
+    assert_success
+    assert_output --partial "Model: gpt-4o"
+}
+
+@test "Claude provider uses claude subagent model (not o3)" {
+    export PROVIDER=claude
+    printf 'Model: {{SUBAGENT_MODEL}}' > "$TEMPLATE"
+    run substitute_prompt "$TEMPLATE"
+    assert_success
+    refute_output --partial "Model: o3"
+}
+
+# --- PROVIDER placeholder ---
+
+@test "PROVIDER placeholder resolves to current provider" {
+    export PROVIDER=codex
+    printf 'Provider: {{PROVIDER}}' > "$TEMPLATE"
+    run substitute_prompt "$TEMPLATE"
+    assert_success
+    assert_output --partial "Provider: codex"
+}
+
+@test "PROVIDER placeholder resolves to claude when default" {
+    unset PROVIDER
+    printf 'Provider: {{PROVIDER}}' > "$TEMPLATE"
+    run substitute_prompt "$TEMPLATE"
+    assert_success
+    assert_output --partial "Provider: claude"
+}
+
+# --- Tag leak prevention ---
+
+@test "conditional tags do not leak into output for claude" {
+    export PROVIDER=claude
+    printf '{{#IF_CLAUDE}}content{{/IF_CLAUDE}}' > "$TEMPLATE"
+    run substitute_prompt "$TEMPLATE"
+    assert_success
+    refute_output --partial "{{#IF_CLAUDE}}"
+    refute_output --partial "{{/IF_CLAUDE}}"
+}
+
+@test "conditional tags do not leak into output for codex" {
+    export PROVIDER=codex
+    printf '{{#IF_CODEX}}content{{/IF_CODEX}}' > "$TEMPLATE"
+    run substitute_prompt "$TEMPLATE"
+    assert_success
+    refute_output --partial "{{#IF_CODEX}}"
+    refute_output --partial "{{/IF_CODEX}}"
+}
+
+@test "stripped block tags do not leak into output" {
+    export PROVIDER=claude
+    printf '{{#IF_CODEX}}codex-only{{/IF_CODEX}}' > "$TEMPLATE"
+    run substitute_prompt "$TEMPLATE"
+    assert_success
+    refute_output --partial "{{#IF_CODEX}}"
+    refute_output --partial "{{/IF_CODEX}}"
+    refute_output --partial "codex-only"
+}
+
+# --- Multiple blocks ---
+
+@test "multiple conditional blocks in same template" {
+    export PROVIDER=claude
+    printf 'A{{#IF_CLAUDE}}B{{/IF_CLAUDE}}C{{#IF_CODEX}}D{{/IF_CODEX}}E{{#IF_CLAUDE}}F{{/IF_CLAUDE}}' > "$TEMPLATE"
+    run substitute_prompt "$TEMPLATE"
+    assert_success
+    assert_output --partial "ABCEF"
+    refute_output --partial "D"
+}
+
+@test "multiple codex blocks all kept when PROVIDER=codex" {
+    export PROVIDER=codex
+    printf '{{#IF_CODEX}}first{{/IF_CODEX}} middle {{#IF_CODEX}}second{{/IF_CODEX}}' > "$TEMPLATE"
+    run substitute_prompt "$TEMPLATE"
+    assert_success
+    assert_output --partial "first"
+    assert_output --partial "second"
+}
+
+# --- Empty blocks ---
+
+@test "empty conditional blocks are handled without error" {
+    export PROVIDER=claude
+    printf 'before{{#IF_CODEX}}{{/IF_CODEX}}after' > "$TEMPLATE"
+    run substitute_prompt "$TEMPLATE"
+    assert_success
+    assert_output --partial "beforeafter"
+}
+
+@test "empty active conditional blocks are handled without error" {
+    export PROVIDER=claude
+    printf 'before{{#IF_CLAUDE}}{{/IF_CLAUDE}}after' > "$TEMPLATE"
+    run substitute_prompt "$TEMPLATE"
+    assert_success
+    assert_output --partial "beforeafter"
+}
+
+# --- Placeholders inside conditional blocks ---
+
+@test "placeholders inside IF_CLAUDE blocks are resolved" {
+    export PROVIDER=claude
+    printf '{{#IF_CLAUDE}}Agent: {{BUILDER_AGENT}}{{/IF_CLAUDE}}' > "$TEMPLATE"
+    run substitute_prompt "$TEMPLATE"
+    assert_success
+    assert_output --partial "Agent: engineer"
+}
+
+@test "placeholders inside IF_CODEX blocks are resolved" {
+    export PROVIDER=codex
+    printf '{{#IF_CODEX}}Model: {{SUBAGENT_MODEL}}{{/IF_CODEX}}' > "$TEMPLATE"
+    run substitute_prompt "$TEMPLATE"
+    assert_success
+    assert_output --partial "Model: o3"
+}
+
+@test "stripped blocks do not expose placeholder values" {
+    export PROVIDER=codex
+    printf '{{#IF_CLAUDE}}Agent: {{BUILDER_AGENT}}{{/IF_CLAUDE}}remaining' > "$TEMPLATE"
+    run substitute_prompt "$TEMPLATE"
+    assert_success
+    refute_output --partial "Agent:"
+    assert_output --partial "remaining"
+}
+
+# --- Footer conditional blocks ---
+
+@test "footer conditional blocks work correctly for codex" {
+    export PROVIDER=codex
+    printf 'Main content' > "$BATS_TEST_TMPDIR/prompts/footer-test.txt"
+    cat > "$BATS_TEST_TMPDIR/prompts/_shared-footer.txt" <<'EOF'
+{{#IF_CLAUDE}}
+Run /exit when done.
+{{/IF_CLAUDE}}
+{{#IF_CODEX}}
+Simply end your response.
+{{/IF_CODEX}}
+EOF
+    run substitute_prompt "$BATS_TEST_TMPDIR/prompts/footer-test.txt"
+    assert_success
+    assert_output --partial "Simply end your response."
+    refute_output --partial "/exit"
+}
+
+@test "footer conditional blocks work correctly for claude" {
+    export PROVIDER=claude
+    printf 'Main content' > "$BATS_TEST_TMPDIR/prompts/footer-test.txt"
+    cat > "$BATS_TEST_TMPDIR/prompts/_shared-footer.txt" <<'EOF'
+{{#IF_CLAUDE}}
+Run /exit when done.
+{{/IF_CLAUDE}}
+{{#IF_CODEX}}
+Simply end your response.
+{{/IF_CODEX}}
+EOF
+    run substitute_prompt "$BATS_TEST_TMPDIR/prompts/footer-test.txt"
+    assert_success
+    assert_output --partial "Run /exit when done."
+    refute_output --partial "Simply end your response."
+}
+
+# --- Real prompt files validation ---
+
+@test "Codex prompts contain no Claude-specific TeamCreate references" {
+    export PROVIDER=codex
+    local real_prompts="$BATS_TEST_DIRNAME/../prompts"
+    local failed=0
+
+    for f in "$real_prompts"/*.txt; do
+        [[ "$(basename "$f")" == "_shared-footer.txt" ]] && continue
+        # Skip scheduled/utility prompts that don't use teams
+        [[ "$(basename "$f")" == "daily-standup.txt" ]] && continue
+        [[ "$(basename "$f")" == "weekly-planning.txt" ]] && continue
+        [[ "$(basename "$f")" == "monthly-strategy.txt" ]] && continue
+        [[ "$(basename "$f")" == "weekly-security-scan.txt" ]] && continue
+        [[ "$(basename "$f")" == "build-tests.txt" ]] && continue
+
+        local output
+        output=$(substitute_prompt "$f" \
+            "REPO=test/repo" \
+            "ISSUE_NUMBER=1" \
+            "ISSUE_TITLE=Test" \
+            "ISSUE_LABELS=agent-work" \
+            "ISSUE_BODY=Test body" \
+            "PR_NUMBER=1" \
+            "PR_TITLE=Test" \
+            "PR_BODY=Test" \
+            "PR_FILES=test.ts" \
+            "PR_DIFF=test" \
+            "PR_BRANCH=test" \
+            "COMPLEXITY=duo" \
+            "TASK_ASSESSMENT=Assessment" \
+            "REVIEW_COMMENTS=None" \
+            "PR_REVIEWS=None" \
+            "MENTION_CONTEXT=")
+
+        if echo "$output" | grep -q 'TeamCreate'; then
+            echo "FAIL: $(basename "$f") contains 'TeamCreate' in Codex mode" >&2
+            failed=1
+        fi
+        if echo "$output" | grep -qE '`Task` tool|the Task tool'; then
+            echo "FAIL: $(basename "$f") contains 'Task tool' reference in Codex mode" >&2
+            failed=1
+        fi
+    done
+
+    [[ "$failed" -eq 0 ]]
+}
+
+@test "Claude prompts contain no leftover conditional tags" {
+    export PROVIDER=claude
+    local real_prompts="$BATS_TEST_DIRNAME/../prompts"
+
+    for f in "$real_prompts"/*.txt; do
+        [[ "$(basename "$f")" == "_shared-footer.txt" ]] && continue
+
+        local output
+        output=$(substitute_prompt "$f" \
+            "REPO=test/repo" \
+            "ISSUE_NUMBER=1" \
+            "ISSUE_TITLE=Test" \
+            "ISSUE_LABELS=agent-work" \
+            "ISSUE_BODY=Test body" \
+            "PR_NUMBER=1" \
+            "PR_TITLE=Test" \
+            "PR_BODY=Test" \
+            "PR_FILES=test.ts" \
+            "PR_DIFF=test" \
+            "PR_BRANCH=test" \
+            "COMPLEXITY=duo" \
+            "TASK_ASSESSMENT=Assessment" \
+            "REVIEW_COMMENTS=None" \
+            "PR_REVIEWS=None" \
+            "MENTION_CONTEXT=")
+
+        if echo "$output" | grep -qF '{{#IF_'; then
+            fail "$(basename "$f") contains leftover {{#IF_ tags in Claude mode"
+        fi
+        if echo "$output" | grep -qF '{{/IF_'; then
+            fail "$(basename "$f") contains leftover {{/IF_ tags in Claude mode"
+        fi
+    done
+}
+
+@test "multiline content in conditional blocks is handled correctly" {
+    export PROVIDER=claude
+    cat > "$TEMPLATE" <<'EOF'
+{{#IF_CLAUDE}}
+Line 1
+Line 2
+Line 3
+{{/IF_CLAUDE}}
+{{#IF_CODEX}}
+Codex line 1
+Codex line 2
+{{/IF_CODEX}}
+EOF
+    run substitute_prompt "$TEMPLATE"
+    assert_success
+    assert_output --partial "Line 1"
+    assert_output --partial "Line 2"
+    assert_output --partial "Line 3"
+    refute_output --partial "Codex line 1"
+}

--- a/tests/test_provider_routing.bats
+++ b/tests/test_provider_routing.bats
@@ -1,0 +1,205 @@
+#!/usr/bin/env bats
+# Tests for label-based provider routing in poll-github.sh
+
+load '../node_modules/bats-support/load'
+load '../node_modules/bats-assert/load'
+
+setup() {
+    export TEST_DIR="$(mktemp -d)"
+
+    # Source the detect_provider_label function by extracting it from poll-github.sh
+    # We re-implement it here to test in isolation (the function relies on jq and grep)
+    detect_provider_label() {
+        local labels="$1"
+        local has_codex=false
+        local has_claude=false
+
+        if [[ "$labels" == "["* ]]; then
+            if echo "$labels" | jq -e '.[] | select(.name == "codex")' &>/dev/null; then
+                has_codex=true
+            fi
+            if echo "$labels" | jq -e '.[] | select(.name == "claude")' &>/dev/null; then
+                has_claude=true
+            fi
+        else
+            if echo ",$labels," | grep -q ",codex,"; then
+                has_codex=true
+            fi
+            if echo ",$labels," | grep -q ",claude,"; then
+                has_claude=true
+            fi
+        fi
+
+        if [[ "$has_claude" == "true" && "$has_codex" == "true" ]]; then
+            export AGENT_PROVIDER="claude"
+        elif [[ "$has_codex" == "true" ]]; then
+            export AGENT_PROVIDER="codex"
+        elif [[ "$has_claude" == "true" ]]; then
+            export AGENT_PROVIDER="claude"
+        else
+            export AGENT_PROVIDER="${AGENT_PROVIDER:-claude}"
+        fi
+    }
+}
+
+teardown() {
+    rm -rf "$TEST_DIR"
+    unset AGENT_PROVIDER
+}
+
+# --- JSON label format tests ---
+
+@test "codex JSON label sets AGENT_PROVIDER=codex" {
+    unset AGENT_PROVIDER
+    detect_provider_label '[{"name":"agent-work"},{"name":"codex"}]'
+    assert_equal "$AGENT_PROVIDER" "codex"
+}
+
+@test "claude JSON label sets AGENT_PROVIDER=claude" {
+    unset AGENT_PROVIDER
+    detect_provider_label '[{"name":"agent"},{"name":"claude"}]'
+    assert_equal "$AGENT_PROVIDER" "claude"
+}
+
+@test "no provider JSON label falls back to env default" {
+    export AGENT_PROVIDER="codex"
+    detect_provider_label '[{"name":"agent-work"},{"name":"feature"}]'
+    assert_equal "$AGENT_PROVIDER" "codex"
+}
+
+@test "no provider JSON label falls back to claude when env unset" {
+    unset AGENT_PROVIDER
+    detect_provider_label '[{"name":"agent-work"}]'
+    assert_equal "$AGENT_PROVIDER" "claude"
+}
+
+@test "conflicting JSON labels prefers claude" {
+    unset AGENT_PROVIDER
+    detect_provider_label '[{"name":"codex"},{"name":"claude"}]'
+    assert_equal "$AGENT_PROVIDER" "claude"
+}
+
+# --- CSV label format tests ---
+
+@test "codex CSV label sets AGENT_PROVIDER=codex" {
+    unset AGENT_PROVIDER
+    detect_provider_label "agent-work,codex,feature"
+    assert_equal "$AGENT_PROVIDER" "codex"
+}
+
+@test "claude CSV label sets AGENT_PROVIDER=claude" {
+    unset AGENT_PROVIDER
+    detect_provider_label "agent,claude"
+    assert_equal "$AGENT_PROVIDER" "claude"
+}
+
+@test "no provider CSV label falls back to env default" {
+    export AGENT_PROVIDER="codex"
+    detect_provider_label "agent-work,feature"
+    assert_equal "$AGENT_PROVIDER" "codex"
+}
+
+@test "no provider CSV label falls back to claude when env unset" {
+    unset AGENT_PROVIDER
+    detect_provider_label "agent-work,feature"
+    assert_equal "$AGENT_PROVIDER" "claude"
+}
+
+@test "conflicting CSV labels prefers claude" {
+    unset AGENT_PROVIDER
+    detect_provider_label "codex,claude,agent-work"
+    assert_equal "$AGENT_PROVIDER" "claude"
+}
+
+@test "empty labels fall back to claude" {
+    unset AGENT_PROVIDER
+    detect_provider_label ""
+    assert_equal "$AGENT_PROVIDER" "claude"
+}
+
+@test "empty JSON array falls back to claude" {
+    unset AGENT_PROVIDER
+    detect_provider_label "[]"
+    assert_equal "$AGENT_PROVIDER" "claude"
+}
+
+# --- CSV substring safety ---
+
+@test "CSV label 'codex-extra' does not match codex" {
+    unset AGENT_PROVIDER
+    detect_provider_label "agent-work,codex-extra"
+    assert_equal "$AGENT_PROVIDER" "claude"
+}
+
+@test "CSV label 'my-claude-thing' does not match claude" {
+    unset AGENT_PROVIDER
+    detect_provider_label "agent-work,my-claude-thing"
+    assert_equal "$AGENT_PROVIDER" "claude"
+}
+
+# --- setup-labels.sh tests ---
+
+@test "setup-labels.sh contains codex label definition" {
+    run grep -c '"codex|74AA9C|Process with OpenAI Codex"' "$(dirname "$BATS_TEST_DIRNAME")/bin/setup-labels.sh"
+    assert_success
+    assert_output "1"
+}
+
+@test "setup-labels.sh contains claude label definition" {
+    run grep -c '"claude|D97706|Process with Claude Code"' "$(dirname "$BATS_TEST_DIRNAME")/bin/setup-labels.sh"
+    assert_success
+    assert_output "1"
+}
+
+# --- Trigger script sourcing tests ---
+
+@test "on-work-issue.sh sources lib/provider.sh" {
+    run grep -c 'source "$SCRIPT_DIR/lib/provider.sh"' "$(dirname "$BATS_TEST_DIRNAME")/triggers/on-work-issue.sh"
+    assert_success
+    assert_output "1"
+}
+
+@test "on-new-issue.sh sources lib/provider.sh" {
+    run grep -c 'source "$SCRIPT_DIR/lib/provider.sh"' "$(dirname "$BATS_TEST_DIRNAME")/triggers/on-new-issue.sh"
+    assert_success
+    assert_output "1"
+}
+
+@test "on-new-pr.sh sources lib/provider.sh" {
+    run grep -c 'source "$SCRIPT_DIR/lib/provider.sh"' "$(dirname "$BATS_TEST_DIRNAME")/triggers/on-new-pr.sh"
+    assert_success
+    assert_output "1"
+}
+
+@test "on-research-issue.sh sources lib/provider.sh" {
+    run grep -c 'source "$SCRIPT_DIR/lib/provider.sh"' "$(dirname "$BATS_TEST_DIRNAME")/triggers/on-research-issue.sh"
+    assert_success
+    assert_output "1"
+}
+
+@test "on-rework-pr.sh sources lib/provider.sh" {
+    run grep -c 'source "$SCRIPT_DIR/lib/provider.sh"' "$(dirname "$BATS_TEST_DIRNAME")/triggers/on-rework-pr.sh"
+    assert_success
+    assert_output "1"
+}
+
+@test "on-test-pr.sh sources lib/provider.sh" {
+    run grep -c 'source "$SCRIPT_DIR/lib/provider.sh"' "$(dirname "$BATS_TEST_DIRNAME")/triggers/on-test-pr.sh"
+    assert_success
+    assert_output "1"
+}
+
+@test "on-write-tests.sh sources lib/provider.sh" {
+    run grep -c 'source "$SCRIPT_DIR/lib/provider.sh"' "$(dirname "$BATS_TEST_DIRNAME")/triggers/on-write-tests.sh"
+    assert_success
+    assert_output "1"
+}
+
+# --- Trigger scripts use launch_agent_session ---
+
+@test "all triggers use launch_agent_session (not launch_claude_session)" {
+    local triggers_dir="$(dirname "$BATS_TEST_DIRNAME")/triggers"
+    # No trigger should directly call launch_claude_session
+    run grep -rl 'launch_claude_session' "$triggers_dir"
+    assert_failure  # grep returns 1 when no matches
+}

--- a/triggers/on-new-issue.sh
+++ b/triggers/on-new-issue.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "$SCRIPT_DIR/lib/common.sh"
 source "$SCRIPT_DIR/lib/item-state.sh"
+source "$SCRIPT_DIR/lib/provider.sh"
 source "$SCRIPT_DIR/lib/tmux-helpers.sh"
 load_env
 
@@ -127,7 +128,7 @@ else
     TMUX_WINDOW="triage-${REPO##*/}-${ISSUE_NUMBER}"
 fi
 
-launch_claude_session "$TMUX_WINDOW" "$EFFECTIVE_PATH" "$PROMPT_FILE"
+launch_agent_session "$TMUX_WINDOW" "$EFFECTIVE_PATH" "$PROMPT_FILE"
 rm -f "$PROMPT_FILE"
 
 # --- Monitor with Timeout ---

--- a/triggers/on-new-pr.sh
+++ b/triggers/on-new-pr.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "$SCRIPT_DIR/lib/common.sh"
 source "$SCRIPT_DIR/lib/item-state.sh"
+source "$SCRIPT_DIR/lib/provider.sh"
 source "$SCRIPT_DIR/lib/tmux-helpers.sh"
 load_env
 
@@ -114,7 +115,7 @@ if echo "$PR_LABELS" | grep -qiw "agent-full-review"; then
 fi
 
 log_info "Complexity classification: $COMPLEXITY for PR #${PR_NUMBER}"
-_log_structured "info" "Complexity classified" "\"complexity\":\"$COMPLEXITY\",\"job_type\":\"review\",\"pr\":$PR_NUMBER,\"repo\":\"$REPO\""
+_log_structured "info" "Complexity classified" "\"complexity\":\"$COMPLEXITY\",\"job_type\":\"review\",\"pr\":$PR_NUMBER,\"repo\":\"$REPO\",\"provider\":\"${AGENT_PROVIDER:-claude}\""
 
 TASK_ASSESSMENT=$(generate_task_assessment "$COMPLEXITY" "review")
 # --- Copy slim CLAUDE.md into worktree ---
@@ -154,7 +155,7 @@ else
     TMUX_WINDOW="review-${REPO##*/}-pr-${PR_NUMBER}"
 fi
 
-launch_claude_session "$TMUX_WINDOW" "$EFFECTIVE_PATH" "$PROMPT_FILE"
+launch_agent_session "$TMUX_WINDOW" "$EFFECTIVE_PATH" "$PROMPT_FILE"
 rm -f "$PROMPT_FILE"
 
 # --- Monitor with Timeout ---

--- a/triggers/on-research-issue.sh
+++ b/triggers/on-research-issue.sh
@@ -9,6 +9,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "$SCRIPT_DIR/lib/common.sh"
 source "$SCRIPT_DIR/lib/item-state.sh"
+source "$SCRIPT_DIR/lib/provider.sh"
 source "$SCRIPT_DIR/lib/tmux-helpers.sh"
 load_env
 
@@ -116,7 +117,7 @@ else
     TMUX_WINDOW="research-${REPO##*/}-${ISSUE_NUMBER}"
 fi
 
-launch_claude_session "$TMUX_WINDOW" "$EFFECTIVE_PATH" "$PROMPT_FILE"
+launch_agent_session "$TMUX_WINDOW" "$EFFECTIVE_PATH" "$PROMPT_FILE"
 rm -f "$PROMPT_FILE"
 
 # --- Monitor with Timeout ---
@@ -146,7 +147,7 @@ gh issue edit "$ISSUE_NUMBER" --repo "$REPO" \
 
 # --- Record Metrics ---
 _log_structured "info" "Research completed for issue #${ISSUE_NUMBER} in ${REPO}" \
-    "\"type\":\"research\",\"repo\":\"$REPO\",\"issue\":$ISSUE_NUMBER"
+    "\"type\":\"research\",\"repo\":\"$REPO\",\"issue\":$ISSUE_NUMBER,\"provider\":\"${AGENT_PROVIDER:-claude}\""
 
 # --- Notify Slack ---
 "$SCRIPT_DIR/bin/notify.sh" \

--- a/triggers/on-rework-pr.sh
+++ b/triggers/on-rework-pr.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "$SCRIPT_DIR/lib/common.sh"
 source "$SCRIPT_DIR/lib/item-state.sh"
+source "$SCRIPT_DIR/lib/provider.sh"
 source "$SCRIPT_DIR/lib/tmux-helpers.sh"
 load_env
 
@@ -147,7 +148,7 @@ if echo "$PR_LABELS" | grep -qiw "agent-full-review"; then
 fi
 
 log_info "Complexity classification: $COMPLEXITY for rework PR #${PR_NUMBER}"
-_log_structured "info" "Complexity classified" "\"complexity\":\"$COMPLEXITY\",\"job_type\":\"rework\",\"pr\":$PR_NUMBER,\"repo\":\"$REPO\""
+_log_structured "info" "Complexity classified" "\"complexity\":\"$COMPLEXITY\",\"job_type\":\"rework\",\"pr\":$PR_NUMBER,\"repo\":\"$REPO\",\"provider\":\"${AGENT_PROVIDER:-claude}\""
 
 TASK_ASSESSMENT=$(generate_task_assessment "$COMPLEXITY" "rework")
 # --- Copy slim CLAUDE.md into worktree ---
@@ -177,7 +178,7 @@ else
     TMUX_WINDOW="rework-${REPO##*/}-pr-${PR_NUMBER}"
 fi
 
-launch_claude_session "$TMUX_WINDOW" "$WORKTREE_DIR" "$PROMPT_FILE"
+launch_agent_session "$TMUX_WINDOW" "$WORKTREE_DIR" "$PROMPT_FILE"
 rm -f "$PROMPT_FILE"
 
 # --- Monitor with Timeout ---

--- a/triggers/on-test-pr.sh
+++ b/triggers/on-test-pr.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "$SCRIPT_DIR/lib/common.sh"
 source "$SCRIPT_DIR/lib/item-state.sh"
+source "$SCRIPT_DIR/lib/provider.sh"
 source "$SCRIPT_DIR/lib/tmux-helpers.sh"
 load_env
 
@@ -131,7 +132,7 @@ else
 fi
 START_TIME=$(date +%s)
 
-launch_claude_session "$TMUX_WINDOW" "$WORKTREE_DIR" "$PROMPT_FILE" "" "${CLAUDE_UTILITY_MODEL:-claude-haiku-4-5-20251001}"
+launch_agent_session "$TMUX_WINDOW" "$WORKTREE_DIR" "$PROMPT_FILE" "" "${CLAUDE_UTILITY_MODEL:-claude-haiku-4-5-20251001}"
 rm -f "$PROMPT_FILE"
 
 # --- Monitor with Timeout ---
@@ -177,7 +178,7 @@ fi
 # --- Record Metrics ---
 if command -v node &>/dev/null && [[ -f "$SCRIPT_DIR/bin/zapat" ]]; then
     "$SCRIPT_DIR/bin/zapat" metrics record "$(cat <<METRICSEOF
-{"timestamp":"$(date -u '+%Y-%m-%dT%H:%M:%SZ')","job":"agent-test","repo":"$REPO","item":"pr#$PR_NUMBER","exit_code":0,"start":"$(date -u -r "$START_TIME" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || echo "")","end":"$(date -u '+%Y-%m-%dT%H:%M:%SZ')","duration_s":$DURATION,"status":"completed"}
+{"timestamp":"$(date -u '+%Y-%m-%dT%H:%M:%SZ')","job":"agent-test","repo":"$REPO","item":"pr#$PR_NUMBER","exit_code":0,"start":"$(date -u -r "$START_TIME" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || echo "")","end":"$(date -u '+%Y-%m-%dT%H:%M:%SZ')","duration_s":$DURATION,"status":"completed","provider":"${AGENT_PROVIDER:-claude}"}
 METRICSEOF
 )" 2>/dev/null || true
 fi

--- a/triggers/on-work-issue.sh
+++ b/triggers/on-work-issue.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "$SCRIPT_DIR/lib/common.sh"
 source "$SCRIPT_DIR/lib/item-state.sh"
+source "$SCRIPT_DIR/lib/provider.sh"
 source "$SCRIPT_DIR/lib/tmux-helpers.sh"
 load_env
 
@@ -141,7 +142,7 @@ if echo "$ISSUE_LABELS" | grep -qiw "agent-full-review"; then
 fi
 
 log_info "Complexity classification: $COMPLEXITY for issue #${ISSUE_NUMBER}"
-_log_structured "info" "Complexity classified" "\"complexity\":\"$COMPLEXITY\",\"job_type\":\"implement\",\"issue\":$ISSUE_NUMBER,\"repo\":\"$REPO\""
+_log_structured "info" "Complexity classified" "\"complexity\":\"$COMPLEXITY\",\"job_type\":\"implement\",\"issue\":$ISSUE_NUMBER,\"repo\":\"$REPO\",\"provider\":\"${AGENT_PROVIDER:-claude}\""
 
 TASK_ASSESSMENT=$(generate_task_assessment "$COMPLEXITY" "implement")
 # --- Copy slim CLAUDE.md into worktree ---
@@ -180,7 +181,7 @@ else
     TMUX_WINDOW="work-${REPO##*/}-${ISSUE_NUMBER}"
 fi
 
-launch_claude_session "$TMUX_WINDOW" "$WORKTREE_DIR" "$PROMPT_FILE"
+launch_agent_session "$TMUX_WINDOW" "$WORKTREE_DIR" "$PROMPT_FILE"
 rm -f "$PROMPT_FILE"
 
 # --- Monitor with Timeout ---

--- a/triggers/on-write-tests.sh
+++ b/triggers/on-write-tests.sh
@@ -8,6 +8,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "$SCRIPT_DIR/lib/common.sh"
 source "$SCRIPT_DIR/lib/item-state.sh"
+source "$SCRIPT_DIR/lib/provider.sh"
 source "$SCRIPT_DIR/lib/tmux-helpers.sh"
 load_env
 
@@ -134,7 +135,7 @@ else
     TMUX_WINDOW="write-tests-${REPO##*/}-${ISSUE_NUMBER}"
 fi
 
-launch_claude_session "$TMUX_WINDOW" "$WORKTREE_DIR" "$PROMPT_FILE"
+launch_agent_session "$TMUX_WINDOW" "$WORKTREE_DIR" "$PROMPT_FILE"
 rm -f "$PROMPT_FILE"
 
 # --- Monitor with Timeout ---


### PR DESCRIPTION
## Summary

Adds multi-provider support to Zapat, enabling the pipeline to dispatch work to either Claude Code or OpenAI Codex CLI based on configuration or per-issue/PR labels.

This is the integration PR for **issue #49** (Make Zapat work with OpenAI Codex), consolidating work from sub-issues #50-#53:

- **#50 — Provider abstraction layer** (`lib/provider.sh`): Pluggable provider interface with `claude.sh` and `codex.sh` implementations. Each provider defines its own CLI invocation, model names, idle/spinner patterns, and tmux credential isolation.
- **#51 — Label-based provider routing**: `codex` and `claude` GitHub labels route issues/PRs to the appropriate provider. `detect_provider_label()` in the poller handles conflict resolution (claude wins if both present).
- **#52 — Codex-compatible prompt templates**: Provider-conditional blocks (`{{#IF_CLAUDE}}`/`{{#IF_CODEX}}`) in all prompt templates. Codex gets solo workflows (no team spawning); Claude keeps full team orchestration.
- **#53 — Framework evolution safeguards**: Auto-merge gate now checks `baseRefName` (skips feature branch PRs), risk classifier flags pipeline-critical files as high risk, post-merge health checks, integration test suite (26 tests), and documented multi-PR feature branch workflow.

### Key architectural decisions

- Provider dispatched via `AGENT_PROVIDER` env var (default: `claude`)
- Provider files sourced at session start, exporting standardized functions (`provider_launch_command`, `provider_model_name`, etc.)
- `AGENT_PROVIDER` validated against path traversal (`^[a-z0-9_-]+$`)
- Tmux credential isolation per provider (Claude uses `CLAUDE_API_KEY`, Codex uses `OPENAI_API_KEY`)

### Infinite loop fix preserved

The critical infinite loop fix (commit `3531748`) is preserved. Verified:
- `increment_rework_cycles` exists in `lib/item-state.sh`
- `on-rework-pr.sh` adds only `zapat-testing` (not `zapat-review`)
- Sequential flow and cycle counter tests pass

### Files changed (30 files, +2698/-271)

**New files:**
- `lib/provider.sh` — Provider abstraction layer
- `lib/providers/claude.sh` — Claude provider implementation
- `lib/providers/codex.sh` — Codex provider implementation
- `tests/test_provider.bats` — Provider unit tests (29 tests)
- `tests/test_provider_routing.bats` — Label routing tests (24 tests)
- `tests/test_provider_conditional.bats` — Conditional block tests
- `tests/test_provider_conditionals.bats` — Additional conditional tests
- `tests/test_integration.bats` — Integration test suite (26 tests)

**Modified files:**
- `bin/poll-github.sh` — Label routing, baseRefName gate, post-merge health check
- `bin/run-agent.sh` — Provider-aware session launch
- `lib/common.sh` — Provider-conditional template processing
- `lib/tmux-helpers.sh` — Provider-sourced idle/spinner patterns
- `src/commands/risk.mjs` — Pipeline-critical file patterns
- `CLAUDE.md` — Slim agent context + feature branch workflow docs
- All `triggers/*.sh` — Provider sourcing before agent dispatch
- All `prompts/*.txt` — Provider-conditional workflow blocks

## Test plan

- [x] Full test suite passes: 407/408 (1 pre-existing failure on main: `devops-engineer.md` > 3KB)
- [x] Integration tests pass: 26/26
- [x] Provider tests pass: 29/29
- [x] Routing tests pass: 24/24
- [x] Infinite loop regression tests pass
- [x] Sequential flow tests pass
- [x] `git diff origin/main...feature/multi-provider-support` reviewed — no unintended deletions
- [ ] Smoke test: `AGENT_PROVIDER=codex` with labeled issue

Closes #49, closes #50, closes #51, closes #52, closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)